### PR TITLE
Fix setting host lost on client app binding

### DIFF
--- a/src/RayServiceProvider.php
+++ b/src/RayServiceProvider.php
@@ -50,7 +50,7 @@ class RayServiceProvider extends ServiceProvider
     {
         $settings = app(Settings::class);
 
-        $this->app->bind(Client::class, fn () => new Client($settings->port), $settings->host);
+        $this->app->bind(Client::class, fn () => new Client($settings->port, $settings->host));
 
         $this->app->bind(Ray::class, function () {
             $client = app(Client::class);


### PR DESCRIPTION
Corrected the bracketing so the host value is passed as an argument to the Client constructor rather than the binding itself

This fixes #16 