### PR TITLE
Support Laravel v6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,9 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "illuminate/contracts": "^7.0|^8.0",
-        "illuminate/database": "^7.0|^8.13",
-        "illuminate/support": "^7.0|^8.13",
+        "illuminate/contracts": "^6.0|^7.0|^8.0",
+        "illuminate/database": "^6.0|^7.0|^8.13",
+        "illuminate/support": "^6.0|^7.0|^8.13",
         "spatie/backtrace": "^1.0",
         "spatie/ray": "^1.3",
         "symfony/stopwatch": "4.2|^5.2"


### PR DESCRIPTION
Related to https://github.com/spatie/laravel-ray/issues/19, updating the illuminate dependencies adds support for Laravel v6.