### PR TITLE
Add `enabled()` and `disabled()` methods

### DIFF
--- a/src/Ray.php
+++ b/src/Ray.php
@@ -28,6 +28,11 @@ class Ray extends BaseRay
         return $this;
     }
 
+    public function enabled(): bool
+    {
+        return self::$enabled;
+    }
+
     public function loggedMail(string $loggedMail): self
     {
         $html = '<html' . Str::between($loggedMail, '<html', '</html>') . '</html>';

--- a/src/Ray.php
+++ b/src/Ray.php
@@ -33,6 +33,11 @@ class Ray extends BaseRay
         return self::$enabled;
     }
 
+    public function disabled(): bool
+    {
+        return ! self::$enabled;
+    }
+
     public function loggedMail(string $loggedMail): self
     {
         $html = '<html' . Str::between($loggedMail, '<html', '</html>') . '</html>';

--- a/tests/RayTest.php
+++ b/tests/RayTest.php
@@ -136,6 +136,16 @@ class RayTest extends TestCase
     }
 
     /** @test */
+    public function it_can_check_disabled_status()
+    {
+        ray()->disable();
+        $this->assertEquals(true, ray()->disabled());
+
+        ray()->enable();
+        $this->assertEquals(false, ray()->disabled());
+    }
+
+    /** @test */
     public function it_can_log_dumps()
     {
         dump('test');

--- a/tests/RayTest.php
+++ b/tests/RayTest.php
@@ -126,6 +126,16 @@ class RayTest extends TestCase
     }
 
     /** @test */
+    public function it_can_check_enabled_status()
+    {
+        ray()->disable();
+        $this->assertEquals(false, ray()->enabled());
+
+        ray()->enable();
+        $this->assertEquals(true, ray()->enabled());
+    }
+
+    /** @test */
     public function it_can_log_dumps()
     {
         dump('test');


### PR DESCRIPTION
I've come across various situations where I need to know if Ray is enabled or disabled. A simple example is choosing between `ray()` and `info()` for logging something in situations where something will always be logged:

```php
if (ray()->enabled()) {
    ray('Received new request')->green();
} else {
    info('Received new request');
}
```

By only using `ray()` the log message is lost if Ray is disabled.

Since `ray.php` lives outside of `config/`, using `config('ray.enable')` doesn't get the status (and would be prone to breaking if we had to use a config check everywhere).

The docs change is in [PR #103 in the main ray repo](https://github.com/spatie/ray/pull/103).