### PR TITLE
Add `env()` vars for each Laravel config setting

### DIFF
--- a/stub/ray.php
+++ b/stub/ray.php
@@ -6,43 +6,41 @@ return [
     *
     * By default, `ray()` will only transmit data in non-production environments.
     */
-    'enable' => true,
+    'enable' => env('RAY_ENABLED', true),
 
     /*
     * When enabled, all things logged to the application log
     * will be sent to Ray as well.
     */
-    'send_log_calls_to_ray' => true,
+    'send_log_calls_to_ray' => env('SEND_LOG_CALLS_TO_RAY', true),
 
     /*
     * When enabled, all things passed to `dump` or `dd`
     * will be sent to Ray as well.
     */
-    'send_dumps_to_ray' => true,
+    'send_dumps_to_ray' => env('SEND_DUMPS_TO_RAY', true),
 
     /*
     * The host used to communicate with the Ray app.
-     *
     * For usage in Docker on Mac or Windows, you can replace host with 'host.docker.internal'
-     *
     * For usage in Homestead on Mac or Windows, you can replace host with '10.0.2.2'
     */
-    'host' => 'localhost',
+    'host' => env('RAY_HOST', 'localhost'),
 
     /*
     * The port number used to communicate with the Ray app.
     */
-    'port' => 23517,
+    'port' => env('RAY_PORT', 23517),
 
     /*
      * Absolute base path for your sites or projects in Homestead,
      * Vagrant, Docker, or another remote development server.
      */
-    'remote_path' => null,
+    'remote_path' => env('RAY_REMOTE_PATH', null),
 
     /*
      * Absolute base path for your sites or projects on your local
      * computer where your IDE or code editor is running on.
      */
-    'local_path' => null,
+    'local_path' => env('RAY_LOCAL_PATH', null),
 ];


### PR DESCRIPTION
This changes the `ray.php` config file to use `env()` for each setting. This makes it easier for multiple developers on a project to use Ray, rather than forcing them to create their own config file. If they use Ray with default settings, it will already work. Otherwise they can tweak their config in their own `.env` as needed.

This also makes it easier to enable/disable Ray on your own local environment as needed, without having to change `ray.php` and risk accidentally committing the change.

The docs change is in [PR #104 in the main ray repo](https://github.com/spatie/ray/pull/104).