### PR TITLE
Laravel 6 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,13 +10,15 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.0, 7.4]
-        laravel: [8.*, 7.*]
+        laravel: [8.*, 7.*, 6.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
           - laravel: 8.*
             testbench: 6.*
           - laravel: 7.*
             testbench: 5.*
+          - laravel: 6.*
+            testbench: 4.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,8 @@
         "symfony/stopwatch": "4.2|^5.2"
     },
     "require-dev": {
-        "illuminate/mail": "^7.0|^8.19",
-        "illuminate/view": "^7.0|^8.19",
+        "illuminate/mail": "^6.0|^7.0|^8.19",
+        "illuminate/view": "^6.0|^7.0|^8.19",
         "orchestra/testbench": "^4.0|^5.0|^6.0",
         "phpunit/phpunit": "^9.3",
         "spatie/phpunit-snapshot-assertions": "^4.2"

--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,9 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "illuminate/contracts": "^7.0|^8.0",
-        "illuminate/database": "^7.0|^8.13",
-        "illuminate/support": "^7.0|^8.13",
+        "illuminate/contracts": "^6.0|^7.0|^8.0",
+        "illuminate/database": "^6.0|^7.0|^8.13",
+        "illuminate/support": "^6.0|^7.0|^8.13",
         "spatie/backtrace": "^1.0",
         "spatie/ray": "^1.3",
         "symfony/stopwatch": "4.2|^5.2"
@@ -27,7 +27,7 @@
     "require-dev": {
         "illuminate/mail": "^7.0|^8.19",
         "illuminate/view": "^7.0|^8.19",
-        "orchestra/testbench": "^5.0|^6.0",
+        "orchestra/testbench": "^4.0|^5.0|^6.0",
         "phpunit/phpunit": "^9.3",
         "spatie/phpunit-snapshot-assertions": "^4.2"
     },


### PR DESCRIPTION
Hi, I've added the relevant dependency versions to support Laravel 6. Since Laravel 6 is LTS and Ray has some "commercial" aspects to it (not just open source), I think this suits and adds extended support for all those projects customers wish to use Ray on that cannot be updated due to client restrictions. Since there is no asterisks on the myray.app site specifying the min Laravel support version, an extended support version seems a good version to use.

I hope this is ok for you. Any issues or concerns let me know and Ill do my best to address.

Resolves https://github.com/spatie/laravel-ray/issues/19

Thanks