### PR TITLE
Allow multiple `?Model` arguments to be passed to `model()`

### DIFF
--- a/src/Ray.php
+++ b/src/Ray.php
@@ -58,11 +58,13 @@ class Ray extends BaseRay
         return $this;
     }
 
-    public function model(?Model $model): self
+    public function model(?Model ...$models): self
     {
-        $payload = new ModelPayload($model);
+        $payloads = array_map(function ($model) {
+            return new ModelPayload($model);
+        }, $models);
 
-        $this->sendRequest($payload);
+        $this->sendRequest($payloads);
 
         return $this;
     }

--- a/tests/RayTest.php
+++ b/tests/RayTest.php
@@ -154,13 +154,26 @@ class RayTest extends TestCase
     }
 
     /** @test */
-    public function it_can_send_models_to_ray()
+    public function it_can_send_one_model_to_ray()
     {
         $user = User::make(['email' => 'john@example.com']);
 
         ray()->model($user);
 
         $this->assertCount(1, $this->client->sentPayloads());
+    }
+
+    /** @test */
+    public function it_can_send_multiple_models_to_ray()
+    {
+        $user1 = User::make(['email' => 'john@example.com']);
+        $user2 = User::make(['email' => 'paul@example.com']);
+        $user3 = User::make(['email' => 'george@example.com']);
+        $user4 = User::make(['email' => 'ringo@example.com']);
+
+        ray()->model($user1, $user2, $user3, $user4);
+
+        $this->assertCount(4, Arr::get($this->client->sentPayloads(), '0.payloads'));
     }
 
     /** @test */


### PR DESCRIPTION
This implements part of #69: allowing multiple `?Model` arguments to be passed to the `model()` method. It _doesn't_ add a `models()` method or allow an `array` or `Collection` to be passed.