### PR TITLE
Send rendered markdown

### DIFF
--- a/src/Payloads/MarkdownPayload.php
+++ b/src/Payloads/MarkdownPayload.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Spatie\LaravelRay\Payloads;
+
+use League\CommonMark\GithubFlavoredMarkdownConverter;
+use Spatie\Ray\Payloads\Payload;
+
+class MarkdownPayload extends Payload
+{
+    protected string $markdown;
+
+    public function __construct(string $markdown)
+    {
+        $this->markdown = $markdown;
+    }
+
+    public function getType(): string
+    {
+        return 'custom';
+    }
+
+    public function getContent(): array
+    {
+        return [
+            'content' => $this->markdownToHtml($this->markdown),
+            'label' => 'Markdown',
+        ];
+    }
+
+    protected function markdownToHtml(string $markdown): string
+    {
+        $converter = new GithubFlavoredMarkdownConverter([
+            'renderer' => [
+                'block_separator' => "<br>\n",
+            ],
+            'html_input' => 'allow',
+            'allow_unsafe_links' => false,
+        ]);
+
+        $html = $converter->convertToHtml($markdown);
+        $html = $this->processCodeBlocks($html);
+        $html = $this->processHeaderTags($html);
+        $css = $this->getCustomStyles();
+
+        return trim("{$css}{$html}");
+    }
+
+    protected function getCustomStyles(): string
+    {
+        // render links as underlined
+        return '<style>a { text-decoration:underline!important; }</style>';
+    }
+
+    protected function processCodeBlocks($html): string
+    {
+        // format code blocks background color, padding, and display width; the background
+        // color changes based on light or dark app theme.
+        return str_replace('<pre><code', '<pre class="w-100 bg-gray-200 dark:bg-gray-800 p-5"><code', $html);
+    }
+
+    protected function processHeaderTags($html): string
+    {
+        // render headers with the correct format and size as divs
+        $html = str_replace(['<h1>', '<h2>', '<h3>', '<h4>'], [
+            '<div class="w-100 block" style="font-size:2.1em!important;">',
+            '<div class="w-100 block" style="font-size:1.8em!important;">',
+            '<div class="w-100 block" style="font-size:1.5em!important;">',
+            '<div class="w-100 block" style="font-size:1.2em!important;">',
+        ], $html);
+
+        // replace closing header tags with closing div tags
+        return preg_replace('~</h[1-4]>~', '</div>', $html);
+    }
+}

--- a/src/Ray.php
+++ b/src/Ray.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Mail\Mailable;
 use Illuminate\Support\Str;
 use Spatie\LaravelRay\Payloads\MailablePayload;
+use Spatie\LaravelRay\Payloads\MarkdownPayload;
 use Spatie\LaravelRay\Payloads\ModelPayload;
 use Spatie\Ray\Ray as BaseRay;
 
@@ -65,6 +66,15 @@ class Ray extends BaseRay
         }, $models);
 
         $this->sendRequest($payloads);
+
+        return $this;
+    }
+
+    public function markdown(string $markdown): self
+    {
+        $payload = new MarkdownPayload($markdown);
+
+        $this->sendRequest($payload);
 
         return $this;
     }

--- a/tests/RayTest.php
+++ b/tests/RayTest.php
@@ -280,7 +280,7 @@ class RayTest extends TestCase
         // fix paths when running unit tests on windows platform (github actions)
         $json = json_encode($data);
         $json = str_replace('D:\\\\a\\\\laravel-ray\\\\laravel-ray', '', $json);
-        $json = str_replace('\\\\', '\\/', $json);
+        $json = str_replace('\\\\', '/', $json);
 
 
         $this->assertMatchesJsonSnapshot($json);

--- a/tests/RayTest.php
+++ b/tests/RayTest.php
@@ -266,4 +266,17 @@ class RayTest extends TestCase
             Arr::get($this->client->sentPayloads(), '0.payloads.0.origin.file')
         );
     }
+
+    /** @test */
+    public function it_can_render_and_send_markdown()
+    {
+        ray()->markdown('## Hello World!');
+
+        $this->assertMatchesOsSafeSnapshot($this->client->sentPayloads());
+    }
+
+    protected function assertMatchesOsSafeSnapshot($data)
+    {
+        $this->assertMatchesJsonSnapshot(json_encode($data));
+    }
 }

--- a/tests/RayTest.php
+++ b/tests/RayTest.php
@@ -277,6 +277,12 @@ class RayTest extends TestCase
 
     protected function assertMatchesOsSafeSnapshot($data)
     {
-        $this->assertMatchesJsonSnapshot(json_encode($data));
+        // fix paths when running unit tests on windows platform (github actions)
+        $json = json_encode($data);
+        $json = str_replace('D:\\\\a\\\\laravel-ray\\\\laravel-ray', '', $json);
+        $json = str_replace('\\\\', '\\/', $json);
+
+
+        $this->assertMatchesJsonSnapshot($json);
     }
 }

--- a/tests/__snapshots__/RayTest__it_can_render_and_send_markdown__1.json
+++ b/tests/__snapshots__/RayTest__it_can_render_and_send_markdown__1.json
@@ -10,7 +10,7 @@
                 },
                 "origin": {
                     "file": "\/tests\/RayTest.php",
-                    "line_number": 273
+                    "line_number": 274
                 }
             }
         ],

--- a/tests/__snapshots__/RayTest__it_can_render_and_send_markdown__1.json
+++ b/tests/__snapshots__/RayTest__it_can_render_and_send_markdown__1.json
@@ -1,0 +1,19 @@
+[
+    {
+        "uuid": "fakeUuid",
+        "payloads": [
+            {
+                "type": "custom",
+                "content": {
+                    "content": "<style>a { text-decoration:underline!important; }<\/style><div class=\"w-100 block\" style=\"font-size:1.8em!important;\">Hello World!<\/div>",
+                    "label": "Markdown"
+                },
+                "origin": {
+                    "file": "\/tests\/RayTest.php",
+                    "line_number": 273
+                }
+            }
+        ],
+        "meta": []
+    }
+]


### PR DESCRIPTION
This PR adds a the `markdown()` method, which takes a string of markdown content as its only parameter.  It renders the markdown into HTML using the `League\CommonMark` package, which is installed alongside Laravel (which is why this PR is for `spatie/laravel-ray` and not `spatie/ray`).

Some post-processing is done to ensure the resulting HTML displays correctly in Ray, such as header tags, links, and code blocks.  Only minor changes are made to make sure the output is as expected.

Unit tests have been added, and a I will be submitting a PR to `spatie/ray` with updated documentation.