### PR TITLE
Add support for headers in logged mailables

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
         "illuminate/support": "^7.0|^8.13",
         "spatie/backtrace": "^1.0",
         "spatie/ray": "^1.7.2",
-        "symfony/stopwatch": "4.2|^5.2"
+        "symfony/stopwatch": "4.2|^5.2",
+        "zbateson/mail-mime-parser": "^1.3"
     },
     "require-dev": {
         "illuminate/mail": "^7.0|^8.19",

--- a/src/Payloads/LoggedMailPayload.php
+++ b/src/Payloads/LoggedMailPayload.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Spatie\LaravelRay\Payloads;
+
+use Illuminate\Mail\Mailable;
+use Spatie\Ray\Payloads\Payload;
+use ZBateson\MailMimeParser\Header\AddressHeader;
+use ZBateson\MailMimeParser\Header\HeaderConsts;
+use ZBateson\MailMimeParser\Header\Part\AddressPart;
+use ZBateson\MailMimeParser\MailMimeParser;
+
+class LoggedMailPayload extends Payload
+{
+    protected string $html = '';
+
+    protected ?Mailable $mailable = null;
+
+    private array $from;
+
+    private ?string $subject;
+
+    private array $to;
+
+    private array $cc;
+
+    private array $bcc;
+
+    public static function forLoggedMail(string $loggedMail): self
+    {
+        $parser = new MailMimeParser();
+
+        $message = $parser->parse($loggedMail);
+
+        return new self(
+            $message->getContent(),
+            self::convertHeaderToPersons($message->getHeader(HeaderConsts::FROM)),
+            $message->getHeaderValue(HeaderConsts::SUBJECT),
+            self::convertHeaderToPersons($message->getHeader(HeaderConsts::TO)),
+            self::convertHeaderToPersons($message->getHeader(HeaderConsts::CC)),
+            self::convertHeaderToPersons($message->getHeader(HeaderConsts::BCC)),
+        );
+    }
+
+    public function __construct(
+        string $html,
+        array $from = [],
+        ?string $subject = null,
+        array $to = [],
+        array $cc = [],
+        array $bcc = []
+    ) {
+        $this->html = $html;
+        $this->from = $from;
+        $this->subject = $subject;
+        $this->to = $to;
+        $this->cc = $cc;
+        $this->bcc = $bcc;
+    }
+
+    public function getType(): string
+    {
+        return 'mailable';
+    }
+
+    public function getContent(): array
+    {
+        return [
+            'html' => $this->html,
+            'subject' => $this->subject,
+            'from' => $this->from,
+            'to' => $this->to,
+            'cc' => $this->cc,
+            'bcc' => $this->bcc,
+        ];
+    }
+
+    protected static function convertHeaderToPersons(?AddressHeader $header): array
+    {
+        if($header === null){
+            return [];
+        }
+
+        return array_map(
+            fn(AddressPart $address) => [
+                'name' => $address->getName(),
+                'email' => $address->getEmail(),
+            ],
+            $header->getAddresses()
+        );
+    }
+}

--- a/src/Payloads/LoggedMailPayload.php
+++ b/src/Payloads/LoggedMailPayload.php
@@ -13,8 +13,6 @@ class LoggedMailPayload extends Payload
 {
     protected string $html = '';
 
-    protected ?Mailable $mailable = null;
-
     private array $from;
 
     private ?string $subject;

--- a/src/Payloads/LoggedMailPayload.php
+++ b/src/Payloads/LoggedMailPayload.php
@@ -76,12 +76,12 @@ class LoggedMailPayload extends Payload
 
     protected static function convertHeaderToPersons(?AddressHeader $header): array
     {
-        if($header === null){
+        if ($header === null) {
             return [];
         }
 
         return array_map(
-            fn(AddressPart $address) => [
+            fn (AddressPart $address) => [
                 'name' => $address->getName(),
                 'email' => $address->getEmail(),
             ],

--- a/src/Payloads/LoggedMailPayload.php
+++ b/src/Payloads/LoggedMailPayload.php
@@ -2,7 +2,6 @@
 
 namespace Spatie\LaravelRay\Payloads;
 
-use Illuminate\Mail\Mailable;
 use Spatie\Ray\Payloads\Payload;
 use ZBateson\MailMimeParser\Header\AddressHeader;
 use ZBateson\MailMimeParser\Header\HeaderConsts;

--- a/src/Ray.php
+++ b/src/Ray.php
@@ -5,8 +5,8 @@ namespace Spatie\LaravelRay;
 use Composer\InstalledVersions;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Mail\Mailable;
-use Illuminate\Support\Str;
 use Illuminate\Testing\TestResponse;
+use Spatie\LaravelRay\Payloads\LoggedMailPayload;
 use Spatie\LaravelRay\Payloads\MailablePayload;
 use Spatie\LaravelRay\Payloads\MarkdownPayload;
 use Spatie\LaravelRay\Payloads\ModelPayload;
@@ -43,9 +43,7 @@ class Ray extends BaseRay
 
     public function loggedMail(string $loggedMail): self
     {
-        $html = '<html' . Str::between($loggedMail, '<html', '</html>') . '</html>';
-
-        $payload = new MailablePayload($html);
+        $payload = LoggedMailPayload::forLoggedMail($loggedMail);
 
         $this->sendRequest($payload);
 

--- a/tests/Payloads/LoggedMailPayloadTest.php
+++ b/tests/Payloads/LoggedMailPayloadTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Spatie\LaravelRay\Tests\Payloads;
+
+use Spatie\LaravelRay\Payloads\LoggedMailPayload;
+use Spatie\LaravelRay\Tests\TestCase;
+
+class LoggedMailPayloadTest extends TestCase
+{
+    /** @test */
+    public function it_can_parse_a_logged_mail()
+    {
+        $loggedMail = <<<EOD
+Message-ID: <780b20b2a80adefb6ebb6c9fb7d15d8a@swift.generated>
+Date: Fri, 15 Jan 2021 08:54:24 +0000
+Subject: Test Mailable
+From: Example <hello@example.com>
+To: Freek <freek@spatie.be>, ruben@spatie.be
+Cc: adriaan@spatie.be, Seb <seb@spatie.be>
+Bcc: willem@spatie.be
+MIME-Version: 1.0
+Content-Type: multipart/alternative;
+
+# fake mail
+EOD;
+
+        $payload = LoggedMailPayload::forLoggedMail($loggedMail);
+
+        $this->assertEquals([
+            'html' => '# fake mail',
+            'subject' => 'Test Mailable',
+            'from' => [
+                [
+                    'name' => 'Example',
+                    'email' => 'hello@example.com',
+                ],
+            ],
+            'to' => [
+                [
+                    'name' => 'Freek',
+                    'email' => 'freek@spatie.be',
+                ],
+                [
+                    'name' => '',
+                    'email' => 'ruben@spatie.be'
+                ]
+            ],
+            'cc' => [
+                [
+                    'name' => '',
+                    'email' => 'adriaan@spatie.be',
+                ],
+                [
+                    'name' => 'Seb',
+                    'email' => 'seb@spatie.be'
+                ]
+            ],
+            'bcc' => [
+                [
+                    'name' => '',
+                    'email' => 'willem@spatie.be',
+                ],
+
+            ],
+        ], $payload->getContent());
+    }
+
+    /** @test */
+    public function it_can_omit_some_headers_in_a_parsed_mail()
+    {
+        $loggedMail = <<<EOD
+From: Example <hello@example.com>
+To: Freek <freek@spatie.be>
+Content-Type: multipart/alternative;
+
+# fake mail
+EOD;
+
+        $payload = LoggedMailPayload::forLoggedMail($loggedMail);
+
+        $this->assertEquals([
+            'html' => '# fake mail',
+            'subject' => null,
+            'from' => [
+                [
+                    'name' => 'Example',
+                    'email' => 'hello@example.com',
+                ],
+            ],
+            'to' => [
+                [
+                    'name' => 'Freek',
+                    'email' => 'freek@spatie.be',
+                ],
+            ],
+            'cc' => [],
+            'bcc' => [],
+        ], $payload->getContent());
+    }
+}

--- a/tests/Payloads/LoggedMailPayloadTest.php
+++ b/tests/Payloads/LoggedMailPayloadTest.php
@@ -42,8 +42,8 @@ EOD;
                 ],
                 [
                     'name' => '',
-                    'email' => 'ruben@spatie.be'
-                ]
+                    'email' => 'ruben@spatie.be',
+                ],
             ],
             'cc' => [
                 [
@@ -52,8 +52,8 @@ EOD;
                 ],
                 [
                     'name' => 'Seb',
-                    'email' => 'seb@spatie.be'
-                ]
+                    'email' => 'seb@spatie.be',
+                ],
             ],
             'bcc' => [
                 [

--- a/tests/Payloads/__snapshots__/MailablePayloadTest__it_can_render_a_mailable__1.txt
+++ b/tests/Payloads/__snapshots__/MailablePayloadTest__it_can_render_a_mailable__1.txt
@@ -1,1 +1,3 @@
-Mailable could not be rendered because View [mails.test] not found.
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
+<html><body style="box-sizing: border-box; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; position: relative; -webkit-text-size-adjust: none; background-color: #ffffff; color: #718096; height: 100%; line-height: 1.4; margin: 0; padding: 0; width: 100% !important;"><p style="box-sizing: border-box; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; position: relative; font-size: 16px; line-height: 1.5em; margin-top: 0; text-align: left;"># fake mail
+</p></body></html>

--- a/tests/RayTest.php
+++ b/tests/RayTest.php
@@ -2,9 +2,13 @@
 
 namespace Spatie\LaravelRay\Tests;
 
+use Illuminate\Mail\Mailer;
+use Illuminate\Mail\MailManager;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\View\FileViewFinder;
 use Log;
 use Spatie\LaravelRay\Tests\TestClasses\TestEvent;
 use Spatie\LaravelRay\Tests\TestClasses\TestMailable;
@@ -193,6 +197,18 @@ class RayTest extends TestCase
     public function it_can_send_the_mailable_payload()
     {
         ray()->mailable(new TestMailable());
+
+        $this->assertCount(1, $this->client->sentPayloads());
+    }
+
+    /** @test */
+    public function it_can_send_a_logged_mailable()
+    {
+        Mail::mailer('log')
+            ->cc(['adriaan' => 'adriaan@spatie.be', 'seb@spatie.be'])
+            ->bcc(['willem@spatie.be', 'jef@spatie.be'])
+            ->to(['freek@spatie.be', 'ruben@spatie.be'])
+            ->send(new TestMailable());
 
         $this->assertCount(1, $this->client->sentPayloads());
     }

--- a/tests/RayTest.php
+++ b/tests/RayTest.php
@@ -2,13 +2,10 @@
 
 namespace Spatie\LaravelRay\Tests;
 
-use Illuminate\Mail\Mailer;
-use Illuminate\Mail\MailManager;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Mail;
-use Illuminate\View\FileViewFinder;
+use Illuminate\Support\Facades\Route;
 use Log;
 use Spatie\LaravelRay\Tests\TestClasses\TestEvent;
 use Spatie\LaravelRay\Tests\TestClasses\TestMailable;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -33,7 +33,7 @@ class TestCase extends Orchestra
             return $ray;
         });
 
-        View::addLocation(__DIR__ . '/resources/view');
+        View::addLocation(__DIR__ . '/resources/views');
     }
 
     protected function getPackageProviders($app)

--- a/tests/__snapshots__/RayTest__it_can_render_and_send_markdown__1.json
+++ b/tests/__snapshots__/RayTest__it_can_render_and_send_markdown__1.json
@@ -10,7 +10,7 @@
                 },
                 "origin": {
                     "file": "\/tests\/RayTest.php",
-                    "line_number": 274
+                    "line_number": 290
                 }
             }
         ],

--- a/tests/resources/views/mails/test.blade.php
+++ b/tests/resources/views/mails/test.blade.php
@@ -1,0 +1,1 @@
+# fake mail


### PR DESCRIPTION
This adds support for headers provided with a logged mailable #47 