### PR TITLE
Automatically use specialised payload

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "illuminate/database": "^7.0|^8.13",
         "illuminate/support": "^7.0|^8.13",
         "spatie/backtrace": "^1.0",
-        "spatie/ray": "^1.7.2",
+        "spatie/ray": "dev-mixed-ray",
         "symfony/stopwatch": "4.2|^5.1",
         "zbateson/mail-mime-parser": "^1.3"
     },

--- a/src/RayServiceProvider.php
+++ b/src/RayServiceProvider.php
@@ -174,7 +174,7 @@ class RayServiceProvider extends ServiceProvider
 
     protected function registerPayloadFinder(): self
     {
-        PayloadFactory::registerPayloadFinder(function($argument) {
+        PayloadFactory::registerPayloadFinder(function ($argument) {
             if ($argument instanceof Model) {
                 return new ModelPayload($argument);
             }

--- a/tests/RayTest.php
+++ b/tests/RayTest.php
@@ -8,7 +8,6 @@ use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Route;
 use Log;
 use Spatie\LaravelRay\Tests\TestClasses\TestEvent;
-use Spatie\LaravelRay\Tests\TestClasses\TestEventWithParameter;
 use Spatie\LaravelRay\Tests\TestClasses\TestMailable;
 use Spatie\LaravelRay\Tests\TestClasses\User;
 use Spatie\Ray\Settings\Settings;

--- a/tests/RayTest.php
+++ b/tests/RayTest.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Route;
 use Log;
 use Spatie\LaravelRay\Tests\TestClasses\TestEvent;
+use Spatie\LaravelRay\Tests\TestClasses\TestEventWithParameter;
 use Spatie\LaravelRay\Tests\TestClasses\TestMailable;
 use Spatie\LaravelRay\Tests\TestClasses\User;
 use Spatie\Ray\Settings\Settings;
@@ -338,6 +339,17 @@ class RayTest extends TestCase
         $this->assertEquals('{"a":1}', Arr::get($this->client->sentPayloads(), '0.payloads.0.content.content'));
         $this->assertEquals('{"a":1}', Arr::get($this->client->sentPayloads(), '0.payloads.0.content.content'));
         $this->assertNotEmpty(Arr::get($this->client->sentPayloads(), '0.payloads.0.content.json'));
+    }
+
+    /** @test */
+    public function it_will_automatically_use_specialized_payloads()
+    {
+        ray(new TestMailable(), new User());
+
+        $payloads = $this->client->sentPayloads();
+
+        $this->assertEquals('mailable', $payloads[0]['payloads'][0]['type']);
+        $this->assertEquals('eloquent_model', $payloads[0]['payloads'][1]['type']);
     }
 
     /** @test */

--- a/tests/__snapshots__/RayTest__it_can_render_and_send_markdown__1.json
+++ b/tests/__snapshots__/RayTest__it_can_render_and_send_markdown__1.json
@@ -10,7 +10,7 @@
                 },
                 "origin": {
                     "file": "\/tests\/RayTest.php",
-                    "line_number": 305
+                    "line_number": 306
                 }
             }
         ],


### PR DESCRIPTION
This PR will make

```
ray(new Mailable, Model::create()),
```

behave the same way as 

```
ray()->mailable(new Mailable);
ray()->model(Model::create());
```

Changes in spatie/ray need to be tagged first.