### PR TITLE
Register watchers during Provider boot()

### DIFF
--- a/src/RayServiceProvider.php
+++ b/src/RayServiceProvider.php
@@ -42,6 +42,11 @@ class RayServiceProvider extends ServiceProvider
             ->registerPayloadFinder();
     }
 
+    public function boot()
+    {
+        $this->bootWatchers();
+    }
+
     protected function registerCommands(): self
     {
         $this->commands(PublishConfigCommand::class);
@@ -114,7 +119,27 @@ class RayServiceProvider extends ServiceProvider
         collect($watchers)
             ->each(function (string $watcherClass) {
                 $this->app->singleton($watcherClass);
-            })
+            });
+
+        return $this;
+    }
+
+    protected function bootWatchers(): self
+    {
+        $watchers = [
+            ExceptionWatcher::class,
+            LoggedMailWatcher::class,
+            ApplicationLogWatcher::class,
+            JobWatcher::class,
+            EventWatcher::class,
+            DumpWatcher::class,
+            QueryWatcher::class,
+            ViewWatcher::class,
+            CacheWatcher::class,
+            RequestWatcher::class,
+        ];
+
+        collect($watchers)
             ->each(function (string $watcherClass) {
                 /** @var \Spatie\LaravelRay\Watchers\Watcher $watcher */
                 $watcher = app($watcherClass);


### PR DESCRIPTION
This PR only registers singletons for the watchers in the `register()` method of the Service Provider.  The `register()` method on each watcher is called during the `boot()` method of the Service Provider.  This is done because in some instances not all dependencies were resolved during the Provider's `register()`, causing various issues.

This was submitted in relation to #137, although it may also resolve #135.