### PR TITLE
Chain colours on `show*` methods

### DIFF
--- a/src/OriginFactory.php
+++ b/src/OriginFactory.php
@@ -66,7 +66,7 @@ class OriginFactory
             $originFrame = $frames[$indexOfRay + $framesAbove] ?? null;
         }
 
-        if (!$rayFrame) {
+        if (! $rayFrame) {
             return null;
         }
 
@@ -133,7 +133,7 @@ class OriginFactory
     {
         $indexOfDumpCall = $frames
             ->search(function (Frame $frame) {
-                if (!is_null($frame->class)) {
+                if (! is_null($frame->class)) {
                     return false;
                 }
 
@@ -204,7 +204,7 @@ class OriginFactory
 
     protected function replaceCompiledViewPathWithOriginalViewPath(Frame $frame): Frame
     {
-        if (!file_exists($frame->file)) {
+        if (! file_exists($frame->file)) {
             return $frame;
         }
 
@@ -212,7 +212,7 @@ class OriginFactory
 
         $originalViewPath = trim(Str::between($fileContents, '/**PATH', 'ENDPATH**/'));
 
-        if (!file_exists($originalViewPath)) {
+        if (! file_exists($originalViewPath)) {
             return $frame;
         }
 

--- a/src/Ray.php
+++ b/src/Ray.php
@@ -114,14 +114,19 @@ class Ray extends BaseRay
         return $this;
     }
 
-    public function showEvents($callable = null): self
+    /**
+     * @param null $callable
+     *
+     * @return \Spatie\LaravelRay\Ray
+     */
+    public function showEvents($callable = null)
     {
         $watcher = app(EventWatcher::class);
 
         return $this->handleWatcherCallable($watcher, $callable);
     }
 
-    public function events($callable = null): self
+    public function events($callable = null)
     {
         return $this->showEvents($callable);
     }
@@ -136,14 +141,24 @@ class Ray extends BaseRay
         return $this;
     }
 
-    public function showJobs($callable = null): self
+    /**
+     * @param null $callable
+     *
+     * @return \Spatie\LaravelRay\Ray
+     */
+    public function showJobs($callable = null)
     {
         $watcher = app(JobWatcher::class);
 
         return $this->handleWatcherCallable($watcher, $callable);
     }
 
-    public function showCache($callable = null): self
+    /**
+     * @param null $callable
+     *
+     * @return \Spatie\LaravelRay\Ray
+     */
+    public function showCache($callable = null)
     {
         $watcher = app(CacheWatcher::class);
 
@@ -157,7 +172,7 @@ class Ray extends BaseRay
         return $this;
     }
 
-    public function jobs($callable = null): self
+    public function jobs($callable = null)
     {
         return $this->showJobs($callable);
     }
@@ -176,14 +191,19 @@ class Ray extends BaseRay
         return $this->sendRequest($payload);
     }
 
-    public function showViews($callable = null): self
+    /**
+     * @param null $callable
+     *
+     * @return \Spatie\LaravelRay\Ray
+     */
+    public function showViews($callable = null)
     {
         $watcher = app(ViewWatcher::class);
 
         return $this->handleWatcherCallable($watcher, $callable);
     }
 
-    public function views($callable = null): self
+    public function views($callable = null)
     {
         return $this->showViews($callable);
     }
@@ -195,14 +215,19 @@ class Ray extends BaseRay
         return $this;
     }
 
-    public function showQueries($callable = null): self
+    /**
+     * @param null $callable
+     *
+     * @return \Spatie\LaravelRay\Ray
+     */
+    public function showQueries($callable = null)
     {
         $watcher = app(QueryWatcher::class);
 
         return $this->handleWatcherCallable($watcher, $callable);
     }
 
-    public function queries($callable = null): self
+    public function queries($callable = null)
     {
         return $this->showQueries($callable);
     }
@@ -214,14 +239,19 @@ class Ray extends BaseRay
         return $this;
     }
 
-    public function showRequests($callable = null): self
+    /**
+     * @param null $callable
+     *
+     * @return \Spatie\LaravelRay\Ray
+     */
+    public function showRequests($callable = null)
     {
         $watcher = app(RequestWatcher::class);
 
         return $this->handleWatcherCallable($watcher, $callable);
     }
 
-    public function requests($callable = null): self
+    public function requests($callable = null)
     {
         return $this->showRequests($callable);
     }
@@ -233,11 +263,17 @@ class Ray extends BaseRay
         return $this;
     }
 
-    public function handleWatcherCallable(Watcher $watcher, Closure $callable = null): self
+    protected function handleWatcherCallable(Watcher $watcher, Closure $callable = null): RayProxy
     {
+        $rayProxy = new RayProxy();
+
         $wasEnabled = $watcher->enabled();
 
         $watcher->enable();
+
+        if ($rayProxy) {
+            $watcher->setRayProxy($rayProxy);
+        }
 
         if ($callable) {
             $callable();
@@ -247,7 +283,7 @@ class Ray extends BaseRay
             }
         }
 
-        return $this;
+        return $rayProxy;
     }
 
     public function testResponse(TestResponse $testResponse)

--- a/src/RayProxy.php
+++ b/src/RayProxy.php
@@ -16,7 +16,7 @@ class RayProxy
 
     public function applyCalledMethods(Ray $ray)
     {
-        foreach($this->methodsCalled as $methodCalled) {
+        foreach ($this->methodsCalled as $methodCalled) {
             call_user_func_array([$ray, $methodCalled['method']], $methodCalled['arguments']);
         }
     }

--- a/src/RayProxy.php
+++ b/src/RayProxy.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Spatie\LaravelRay;
+
+use Spatie\Ray\Ray;
+
+class RayProxy
+{
+    /** @var array */
+    protected $methodsCalled = [];
+
+    public function __call($method, $arguments)
+    {
+        $this->methodsCalled[] = compact('method', 'arguments');
+    }
+
+    public function applyCalledMethods(Ray $ray)
+    {
+        foreach($this->methodsCalled as $methodCalled) {
+            call_user_func_array([$ray, $methodCalled['method']], $methodCalled['arguments']);
+        }
+    }
+}

--- a/src/Watchers/CacheWatcher.php
+++ b/src/Watchers/CacheWatcher.php
@@ -25,7 +25,9 @@ class CacheWatcher extends Watcher
 
             $payload = new CachePayload('Hit', $event->key, $event->value);
 
-            $this->ray()->sendRequest($payload);
+            $ray = $this->ray()->sendRequest($payload);
+
+            $this->rayProxy->applyCalledMethods($ray);
         });
 
         app('events')->listen(CacheMissed::class, function (CacheMissed $event) {

--- a/src/Watchers/EventWatcher.php
+++ b/src/Watchers/EventWatcher.php
@@ -17,7 +17,9 @@ class EventWatcher extends Watcher
 
             $payload = new EventPayload($eventName, $arguments);
 
-            app(Ray::class)->sendRequest($payload);
+            $ray = app(Ray::class)->sendRequest($payload);
+
+            $this->rayProxy->applyCalledMethods($ray);
         });
     }
 }

--- a/src/Watchers/JobWatcher.php
+++ b/src/Watchers/JobWatcher.php
@@ -31,7 +31,9 @@ class JobWatcher extends Watcher
 
             $payload = new JobEventPayload($event);
 
-            app(Ray::class)->sendRequest($payload);
+            $ray = app(Ray::class)->sendRequest($payload);
+
+            $this->rayProxy->applyCalledMethods($ray);
         });
     }
 }

--- a/src/Watchers/QueryWatcher.php
+++ b/src/Watchers/QueryWatcher.php
@@ -23,7 +23,9 @@ class QueryWatcher extends Watcher
 
             $payload = new ExecutedQueryPayload($query);
 
-            app(Ray::class)->sendRequest($payload);
+            $ray = app(Ray::class)->sendRequest($payload);
+
+            $this->rayProxy->applyCalledMethods($ray);
         });
     }
 

--- a/src/Watchers/RequestWatcher.php
+++ b/src/Watchers/RequestWatcher.php
@@ -28,11 +28,13 @@ class RequestWatcher extends Watcher
                 return;
             }
 
-            $this->handleRequest($event->request, $event->response);
+            $ray = $this->handleRequest($event->request, $event->response);
+
+            $this->rayProxy->applyCalledMethods($ray);
         });
     }
 
-    protected function handleRequest(Request $request, Response $response)
+    protected function handleRequest(Request $request, Response $response): Ray
     {
         $startTime = defined('LARAVEL_START')
             ? LARAVEL_START
@@ -63,7 +65,7 @@ class RequestWatcher extends Watcher
             'Memory' => round(memory_get_peak_usage(true) / 1024 / 1024, 1),
         ], 'Request');
 
-        app(Ray::class)->sendRequest($payload);
+        return app(Ray::class)->sendRequest($payload);
     }
 
     private function payload(Request $request)

--- a/src/Watchers/ViewWatcher.php
+++ b/src/Watchers/ViewWatcher.php
@@ -22,7 +22,9 @@ class ViewWatcher extends Watcher
             /** @var \Illuminate\View\View $view */
             $view = $data[0];
 
-            app(Ray::class)->view($view);
+            $ray = app(Ray::class)->view($view);
+
+            $this->rayProxy->applyCalledMethods($ray);
         });
     }
 }

--- a/src/Watchers/Watcher.php
+++ b/src/Watchers/Watcher.php
@@ -2,10 +2,15 @@
 
 namespace Spatie\LaravelRay\Watchers;
 
+use Spatie\LaravelRay\RayProxy;
+
 abstract class Watcher
 {
     /** @var bool */
     protected $enabled = false;
+
+    /** @var \Spatie\LaravelRay\RayProxy|null */
+    protected $rayProxy;
 
     abstract public function register(): void;
 
@@ -24,6 +29,13 @@ abstract class Watcher
     public function disable(): Watcher
     {
         $this->enabled = false;
+
+        return $this;
+    }
+
+    public function setRayProxy(RayProxy $rayProxy): Watcher
+    {
+        $this->rayProxy = $rayProxy;
 
         return $this;
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -63,11 +63,10 @@ class TestCase extends Orchestra
 
     protected function useRealUuid()
     {
-        $this->app->bind(Ray::class, function() {
+        $this->app->bind(Ray::class, function () {
             Ray::$fakeUuid = null;
 
             return Ray::create($this->client);
-
         });
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -60,4 +60,14 @@ class TestCase extends Orchestra
             $table->bigInteger('id');
         });
     }
+
+    protected function useRealUuid()
+    {
+        $this->app->bind(Ray::class, function() {
+            Ray::$fakeUuid = null;
+
+            return Ray::create($this->client);
+
+        });
+    }
 }

--- a/tests/Unit/EventTest.php
+++ b/tests/Unit/EventTest.php
@@ -3,6 +3,7 @@
 namespace Spatie\LaravelRay\Tests\Unit;
 
 use Illuminate\Support\Arr;
+use Spatie\LaravelRay\Ray;
 use Spatie\LaravelRay\Tests\TestCase;
 use Spatie\LaravelRay\Tests\TestClasses\TestEvent;
 
@@ -63,5 +64,21 @@ class EventTest extends TestCase
 
         $this->assertCount(1, $this->client->sentPayloads());
         $this->assertEquals('event in callable', Arr::get($this->client->sentPayloads(), '0.payloads.0.content.name'));
+    }
+
+    /** @test */
+    public function show_events_can_be_colorized()
+    {
+        $this->useRealUuid();
+
+        ray()->showEvents()->green();
+
+        event('my event');
+
+        $sentPayloads = $this->client->sentPayloads();
+
+        $this->assertCount(2, $sentPayloads);
+        $this->assertEquals($sentPayloads[0]['uuid'], $sentPayloads[1]['uuid']);
+        $this->assertNotEquals('fakeUuid', $sentPayloads[0]['uuid']);
     }
 }

--- a/tests/Unit/JobTest.php
+++ b/tests/Unit/JobTest.php
@@ -22,4 +22,20 @@ class JobTest extends TestCase
         $this->assertEquals('job_event', Arr::get($this->client->sentPayloads(), '0.payloads.0.type'));
         $this->assertCount(2, $this->client->sentPayloads());
     }
+
+    /** @test */
+    public function show_jobs_can_be_colorized()
+    {
+        $this->useRealUuid();
+
+        ray()->showJobs()->green();
+
+        dispatch(new TestJob());
+
+        $sentPayloads = $this->client->sentPayloads();
+
+        $this->assertCount(4, $sentPayloads);
+        $this->assertEquals($sentPayloads[0]['uuid'], $sentPayloads[1]['uuid']);
+        $this->assertNotEquals('fakeUuid', $sentPayloads[0]['uuid']);
+    }
 }

--- a/tests/Unit/QueryTest.php
+++ b/tests/Unit/QueryTest.php
@@ -65,4 +65,20 @@ class QueryTest extends TestCase
         DB::table('users')->get('id');
         $this->assertCount(1, $this->client->sentPayloads());
     }
+
+    /** @test */
+    public function show_queries_can_be_colorized()
+    {
+        $this->useRealUuid();
+
+        ray()->showQueries()->green();
+
+        DB::table('users')->where('id', 1)->get();
+
+        $sentPayloads = $this->client->sentPayloads();
+
+        $this->assertCount(2, $sentPayloads);
+        $this->assertEquals($sentPayloads[0]['uuid'], $sentPayloads[1]['uuid']);
+        $this->assertNotEquals('fakeUuid', $sentPayloads[0]['uuid']);
+    }
 }

--- a/tests/Unit/RequestTest.php
+++ b/tests/Unit/RequestTest.php
@@ -64,4 +64,20 @@ class RequestTest extends TestCase
 
         $this->assertEquals(302, Arr::get($this->client->sentPayloads(), '0.payloads.0.content.values')['Response code']);
     }
+
+    /** @test */
+    public function show_request_can_be_colorized()
+    {
+        $this->useRealUuid();
+
+        ray()->showRequests()->green();
+
+        $this->get('test-redirect');
+
+        $sentPayloads = $this->client->sentPayloads();
+
+        $this->assertCount(2, $sentPayloads);
+        $this->assertEquals($sentPayloads[0]['uuid'], $sentPayloads[1]['uuid']);
+        $this->assertNotEquals('fakeUuid', $sentPayloads[0]['uuid']);
+    }
 }

--- a/tests/Unit/ViewTest.php
+++ b/tests/Unit/ViewTest.php
@@ -17,4 +17,20 @@ class ViewTest extends TestCase
         $this->assertCount(1, $payloads);
         $this->assertEquals('view', $payloads[0]['payloads'][0]['type']);
     }
+
+    /** @test */
+    public function show_views_can_be_colorized()
+    {
+        $this->useRealUuid();
+
+        ray()->showViews()->green();
+
+        view('test')->render();
+
+        $sentPayloads = $this->client->sentPayloads();
+
+        $this->assertCount(2, $sentPayloads);
+        $this->assertEquals($sentPayloads[0]['uuid'], $sentPayloads[1]['uuid']);
+        $this->assertNotEquals('fakeUuid', $sentPayloads[0]['uuid']);
+    }
 }


### PR DESCRIPTION
This PR allows all the color functions to be chained on all `show*` functions

```php
ray()->showQueries()->green() // all displayed queries will be displayed in a green color.
```