### PR TITLE
Replace spaces with underscores in `env()` calls

### DIFF
--- a/stub/ray.php
+++ b/stub/ray.php
@@ -11,7 +11,7 @@ return [
     /*
     * When enabled, all cache events  will automatically be sent to Ray.
     */
-    'send_cache_to_ray' => env('SEND CACHE_TO_RAY', false),
+    'send_cache_to_ray' => env('SEND_CACHE_TO_RAY', false),
 
     /*
     * When enabled, all things passed to `dump` or `dd`
@@ -22,7 +22,7 @@ return [
     /*
     * When enabled all job events will automatically be sent to Ray.
     */
-    'send_jobs_to_ray' => env('SEND JOBS_TO_RAY', false),
+    'send_jobs_to_ray' => env('SEND_JOBS_TO_RAY', false),
 
     /*
     * When enabled, all things logged to the application log
@@ -33,17 +33,17 @@ return [
     /*
     * When enabled, all queries will automatically be sent to Ray.
     */
-    'send_queries_to_ray' => env('SEND QUERIES_TO_RAY', false),
+    'send_queries_to_ray' => env('SEND_QUERIES_TO_RAY', false),
 
     /*
     * When enabled, all requests made to this app will automatically be sent to Ray.
     */
-    'send_requests_to_ray' => env('SEND REQUESTS_TO_RAY', false),
+    'send_requests_to_ray' => env('SEND_REQUESTS_TO_RAY', false),
 
     /*
     * When enabled, all views that are rendered automatically be sent to Ray.
     */
-    'send_views_to_ray' => env('SEND VIEWS_TO_RAY', false),
+    'send_views_to_ray' => env('SEND_VIEWS_TO_RAY', false),
 
     /*
     * The host used to communicate with the Ray app.


### PR DESCRIPTION
Fixes an issue mentioned in a comment on [this commit](https://github.com/spatie/laravel-ray/commit/7c94380be3d0ba8f98cdb8e2d060c5796460983c)