### PR TITLE
Fix "Package spatie/laravel-ray is not installed" exception

### DIFF
--- a/src/Ray.php
+++ b/src/Ray.php
@@ -316,7 +316,11 @@ class Ray extends BaseRay
         ];
 
         if (class_exists(InstalledVersions::class)) {
-            $meta['laravel_ray_package_version'] = InstalledVersions::getVersion('spatie/laravel-ray');
+            try {
+                $meta['laravel_ray_package_version'] = InstalledVersions::getVersion('spatie/laravel-ray');
+            } catch (\Exception $e) {
+                $meta['laravel_ray_package_version'] = '0.0.0';
+            }
         }
 
         return BaseRay::sendRequest($payloads, $meta);


### PR DESCRIPTION
This PR fixes an occasional bug that causes an exception to be thrown when checking the `spatie/laravel-ray` package version. In the event of an exception, it is now suppressed and a default value for the package version is used.

This should resolve issues #153, #155.