### PR TITLE
Origin hostname fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "illuminate/queue": "^7.20|^8.13",
         "illuminate/support": "^7.20|^8.13",
         "spatie/backtrace": "^1.0",
-        "spatie/ray": "^1.20",
+        "spatie/ray": "^1.21",
         "symfony/stopwatch": "4.2|^5.1",
         "zbateson/mail-mime-parser": "^1.3.1"
     },

--- a/src/OriginFactory.php
+++ b/src/OriginFactory.php
@@ -16,8 +16,11 @@ use Spatie\LaravelRay\DumpRecorder\DumpRecorder;
 use Spatie\LaravelRay\Watchers\CacheWatcher;
 use Spatie\LaravelRay\Watchers\QueryWatcher;
 use Spatie\LaravelRay\Watchers\ViewWatcher;
+use Spatie\Ray\Origin\Hostname;
 use Spatie\Ray\Origin\Origin;
 use Spatie\Ray\Ray;
+
+
 
 class OriginFactory
 {
@@ -28,6 +31,7 @@ class OriginFactory
         return new Origin(
             optional($frame)->file,
             optional($frame)->lineNumber,
+            Hostname::get()
         );
     }
 

--- a/tests/Unit/CacheTest.php
+++ b/tests/Unit/CacheTest.php
@@ -4,9 +4,17 @@ namespace Spatie\LaravelRay\Tests\Unit;
 
 use Illuminate\Support\Facades\Cache;
 use Spatie\LaravelRay\Tests\TestCase;
+use Spatie\Ray\Origin\Hostname;
 
 class CacheTest extends TestCase
 {
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Hostname::set('fake-hostname');
+    }
+
     /** @test */
     public function it_can_detect_when_something_gets_cached()
     {

--- a/tests/Unit/MarkdownTest.php
+++ b/tests/Unit/MarkdownTest.php
@@ -3,9 +3,17 @@
 namespace Spatie\LaravelRay\Tests\Unit;
 
 use Spatie\LaravelRay\Tests\TestCase;
+use Spatie\Ray\Origin\Hostname;
 
 class MarkdownTest extends TestCase
 {
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Hostname::set('fake-hostname');
+    }
+
     /** @test */
     public function it_can_render_and_send_markdown()
     {

--- a/tests/Unit/__snapshots__/CacheTest__it_can_detect_when_something_gets_cached__1.json
+++ b/tests/Unit/__snapshots__/CacheTest__it_can_detect_when_something_gets_cached__1.json
@@ -14,7 +14,8 @@
                 },
                 "origin": {
                     "file": "\/tests\/Unit\/CacheTest.php",
-                    "line_number": 15
+                    "line_number": 23,
+                    "hostname": "fake-hostname"
                 }
             }
         ],

--- a/tests/Unit/__snapshots__/CacheTest__it_can_detect_when_something_gets_temporarily_cached__1.json
+++ b/tests/Unit/__snapshots__/CacheTest__it_can_detect_when_something_gets_temporarily_cached__1.json
@@ -15,7 +15,8 @@
                 },
                 "origin": {
                     "file": "\/tests\/Unit\/CacheTest.php",
-                    "line_number": 69
+                    "line_number": 77,
+                    "hostname": "fake-hostname"
                 }
             }
         ],

--- a/tests/Unit/__snapshots__/CacheTest__it_can_detect_when_something_is_cleared_from_the_cache__1.json
+++ b/tests/Unit/__snapshots__/CacheTest__it_can_detect_when_something_is_cleared_from_the_cache__1.json
@@ -15,7 +15,8 @@
                 },
                 "origin": {
                     "file": "\/tests\/Unit\/CacheTest.php",
-                    "line_number": 79
+                    "line_number": 87,
+                    "hostname": "fake-hostname"
                 }
             }
         ],
@@ -36,7 +37,8 @@
                 },
                 "origin": {
                     "file": "\/tests\/Unit\/CacheTest.php",
-                    "line_number": 81
+                    "line_number": 89,
+                    "hostname": "fake-hostname"
                 }
             }
         ],
@@ -56,7 +58,8 @@
                 },
                 "origin": {
                     "file": "\/tests\/Unit\/CacheTest.php",
-                    "line_number": 81
+                    "line_number": 89,
+                    "hostname": "fake-hostname"
                 }
             }
         ],

--- a/tests/Unit/__snapshots__/CacheTest__it_can_detect_when_the_cache_is_hit__1.json
+++ b/tests/Unit/__snapshots__/CacheTest__it_can_detect_when_the_cache_is_hit__1.json
@@ -14,7 +14,8 @@
                 },
                 "origin": {
                     "file": "\/tests\/Unit\/CacheTest.php",
-                    "line_number": 47
+                    "line_number": 55,
+                    "hostname": "fake-hostname"
                 }
             }
         ],
@@ -35,7 +36,8 @@
                 },
                 "origin": {
                     "file": "\/tests\/Unit\/CacheTest.php",
-                    "line_number": 49
+                    "line_number": 57,
+                    "hostname": "fake-hostname"
                 }
             }
         ],

--- a/tests/Unit/__snapshots__/CacheTest__it_can_detect_when_the_cache_is_missed__1.json
+++ b/tests/Unit/__snapshots__/CacheTest__it_can_detect_when_the_cache_is_missed__1.json
@@ -13,7 +13,8 @@
                 },
                 "origin": {
                     "file": "\/tests\/Unit\/CacheTest.php",
-                    "line_number": 59
+                    "line_number": 67,
+                    "hostname": "fake-hostname"
                 }
             }
         ],

--- a/tests/Unit/__snapshots__/MarkdownTest__it_can_render_and_send_markdown__1.json
+++ b/tests/Unit/__snapshots__/MarkdownTest__it_can_render_and_send_markdown__1.json
@@ -10,7 +10,8 @@
                 },
                 "origin": {
                     "file": "\/tests\/Unit\/MarkdownTest.php",
-                    "line_number": 12
+                    "line_number": 20,
+                    "hostname": "fake-hostname"
                 }
             }
         ],


### PR DESCRIPTION
This PR updates the `OriginFactory` class to send the hostname along with other data.  This functionality was added in `spatie/ray` v1.21.0.  The `composer.json` version requirement for `spatie/ray` was also bumped to `^1.21.0`.

Tests and test snapshots were also updated to reflect the hostname requirement.