### PR TITLE
Fix handling of null logs

### DIFF
--- a/src/Watchers/ApplicationLogWatcher.php
+++ b/src/Watchers/ApplicationLogWatcher.php
@@ -44,6 +44,10 @@ class ApplicationLogWatcher extends Watcher
             return false;
         }
 
+        if(is_null($message->message)) {
+            return false;
+        }
+
         /** @var Ray $ray */
         $ray = app(Ray::class);
 

--- a/tests/Unit/LogTest.php
+++ b/tests/Unit/LogTest.php
@@ -25,4 +25,12 @@ class LogTest extends TestCase
 
         $this->assertCount(0, $this->client->sentPayloads());
     }
+
+    /** @test */
+    public function it_will_not_send_logs_to_ray_when_log_is_null()
+    {
+        Log::info(null);
+
+        $this->assertCount(0, $this->client->sentPayloads());
+    }
 }


### PR DESCRIPTION
When logging, you can by accident log null. This will throw an exception in laravel-ray as it expects the message to be a string.