### PR TITLE
Enable/disable sending exceptions to Ray

### DIFF
--- a/src/Ray.php
+++ b/src/Ray.php
@@ -17,6 +17,7 @@ use Spatie\LaravelRay\Payloads\ResponsePayload;
 use Spatie\LaravelRay\Payloads\ViewPayload;
 use Spatie\LaravelRay\Watchers\CacheWatcher;
 use Spatie\LaravelRay\Watchers\EventWatcher;
+use Spatie\LaravelRay\Watchers\ExceptionWatcher;
 use Spatie\LaravelRay\Watchers\JobWatcher;
 use Spatie\LaravelRay\Watchers\QueryWatcher;
 use Spatie\LaravelRay\Watchers\RequestWatcher;
@@ -155,6 +156,26 @@ class Ray extends BaseRay
         $eventWatcher = app(EventWatcher::class);
 
         $eventWatcher->disable();
+
+        return $this;
+    }
+
+    public function showExceptions(): self
+    {
+        /** @var \Spatie\LaravelRay\Watchers\ExceptionWatcher $exceptionWatcher */
+        $exceptionWatcher = app(ExceptionWatcher::class);
+
+        $exceptionWatcher->enable();
+
+        return $this;
+    }
+
+    public function stopShowingExceptions(): self
+    {
+        /** @var \Spatie\LaravelRay\Watchers\ExceptionWatcher $exceptionWatcher */
+        $exceptionWatcher = app(ExceptionWatcher::class);
+
+        $exceptionWatcher->disable();
 
         return $this;
     }

--- a/src/RayServiceProvider.php
+++ b/src/RayServiceProvider.php
@@ -68,6 +68,7 @@ class RayServiceProvider extends ServiceProvider
                 'send_queries_to_ray' => env('SEND_QUERIES_TO_RAY', false),
                 'send_requests_to_ray' => env('SEND_REQUESTS_TO_RAY', false),
                 'send_views_to_ray' => env('SEND_VIEWS_TO_RAY', false),
+                'send_exceptions_to_ray' => env('SEND_EXCEPTIONS_TO_RAY', false),
             ]);
         });
 

--- a/src/Watchers/ExceptionWatcher.php
+++ b/src/Watchers/ExceptionWatcher.php
@@ -8,13 +8,16 @@ use Facade\FlareClient\Truncation\ReportTrimmer;
 use Illuminate\Log\Events\MessageLogged;
 use Illuminate\Support\Facades\Event;
 use Spatie\LaravelRay\Ray;
+use Spatie\Ray\Settings\Settings;
 use Throwable;
 
 class ExceptionWatcher extends Watcher
 {
     public function register(): void
     {
-        $this->enable();
+        $settings = app(Settings::class);
+
+        $this->enabled = $settings->send_exceptions_to_ray;
 
         Event::listen(MessageLogged::class, function (MessageLogged $message) {
             if (! $this->enabled()) {

--- a/stub/ray.php
+++ b/stub/ray.php
@@ -46,6 +46,11 @@ return [
     'send_views_to_ray' => env('SEND_VIEWS_TO_RAY', false),
 
     /*
+     * When enabled, all exceptions will be automatically sent to Ray.
+     */
+    'send_exceptions_to_ray' => env('SEND_EXCEPTIONS_TO_RAY', true),
+
+    /*
     * The host used to communicate with the Ray app.
     * When using Docker on Mac or Windows, you can replace localhost with 'host.docker.internal'
     * When using Homestead with the VirtualBox provider, you can replace localhost with '10.0.2.2'

--- a/tests/RayTest.php
+++ b/tests/RayTest.php
@@ -133,8 +133,6 @@ class RayTest extends TestCase
 
         $payloads = $this->client->sentPayloads();
 
-        print_r($payloads[0]['payloads'][0]['content']['values']);
-
         $this->assertEquals('table', $payloads[0]['payloads'][0]['type']);
         $this->assertEquals('.env', $payloads[0]['payloads'][0]['content']['label']);
         $this->assertEquals('local', $payloads[0]['payloads'][0]['content']['values']['APP_ENV']);

--- a/tests/Unit/ExceptionTest.php
+++ b/tests/Unit/ExceptionTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Spatie\LaravelRay\Tests\Unit;
+
+use Illuminate\Log\Events\MessageLogged;
+use Spatie\LaravelRay\Tests\TestCase;
+
+class ExceptionTest extends TestCase
+{
+    /** @test */
+    public function it_will_not_send_exceptions_to_ray_if_disabled()
+    {
+        ray()->stopShowingExceptions();
+
+        $hasError = false;
+
+        try {
+            event(new MessageLogged('warning', 'test', ['exception' => new \Exception('test')]));
+        } catch (\Exception $e) {
+            $hasError = true;
+        }
+
+        $this->assertFalse($hasError);
+    }
+}


### PR DESCRIPTION
This PR adds the ability to toggle the `ExceptionWatcher` class, which automatically sends exceptions to Ray.  
Specifically, it adds: 
- a `send_exceptions_to_ray` configuration setting
- a `showExceptions` method to the `Ray` class
- a `stopShowingExceptions` method to the `Ray` class

This was a feature request originally from [`spatie/ray #350`](https://github.com/spatie/ray/discussions/350).