### PR TITLE
Color all high severity log messages red

### DIFF
--- a/src/Watchers/ApplicationLogWatcher.php
+++ b/src/Watchers/ApplicationLogWatcher.php
@@ -28,12 +28,16 @@ class ApplicationLogWatcher extends Watcher
 
             $ray->sendRequest($payload);
 
-            if ($message->level === 'error') {
-                $ray->color('red');
-            }
-
-            if ($message->level === 'warning') {
-                $ray->color('orange');
+            switch ($message->level) {
+                case 'error':
+                case 'critical':
+                case 'alert':
+                case 'emergency':
+                    $ray->color('red');
+                    break;
+                case 'warning':
+                    $ray->color('orange');
+                    break;
             }
         });
     }


### PR DESCRIPTION
I think it makes sense to add the red color to `critical`, `alert` and `emergency` log messages.

If you like, I could add some tests asserting that the payloads get the expected color.

I'm curious if there's a reason why color values are passed as "magic" strings, and not defined as constants like `ColorPayload::GREEN` for instance?