### PR TITLE
Remove unnecessary property check in Cache watcher

### DIFF
--- a/src/Watchers/CacheWatcher.php
+++ b/src/Watchers/CacheWatcher.php
@@ -69,10 +69,9 @@ class CacheWatcher extends Watcher
         });
     }
 
-    protected function formatExpiration(KeyWritten $event)
+    protected function formatExpiration(KeyWritten $event): ?int
     {
-        return property_exists($event, 'seconds')
-            ? $event->seconds : $event->minutes * 60;
+        return $event->seconds;
     }
 
     public function ray(): Ray


### PR DESCRIPTION
The `KeyWritten` event does not have the property minutes, nor does the parent class `CacheEvent` and as neither are macroable they check is not needed.
