### PR TITLE
Add tags to cache payload

### DIFF
--- a/src/Payloads/CachePayload.php
+++ b/src/Payloads/CachePayload.php
@@ -10,6 +10,9 @@ class CachePayload extends Payload
     /** @var string */
     protected $type;
 
+    /** @var string[] */
+    protected $tags;
+
     /** @var string */
     protected $key;
 
@@ -19,11 +22,13 @@ class CachePayload extends Payload
     /** @var int|null */
     protected $expirationInSeconds;
 
-    public function __construct(string $type, string $key, $value = null, int $expirationInSeconds = null)
+    public function __construct(string $type, string $key, array|string $tags, $value = null, int $expirationInSeconds = null)
     {
         $this->type = $type;
 
         $this->key = $key;
+
+        $this->tags = is_string($tags) ? [$tags] : $tags;
 
         $this->value = $value;
 
@@ -41,6 +46,7 @@ class CachePayload extends Payload
             'Event' => '<code>' . $this->type . '</code>',
             'Key' => $this->key,
             'Value' => ArgumentConverter::convertToPrimitive($this->value),
+            'Tags' => count($this->tags) ? ArgumentConverter::convertToPrimitive($this->tags) : null,
             'Expiration in seconds' => $this->expirationInSeconds,
         ]);
 

--- a/src/Watchers/CacheWatcher.php
+++ b/src/Watchers/CacheWatcher.php
@@ -23,7 +23,7 @@ class CacheWatcher extends Watcher
                 return;
             }
 
-            $payload = new CachePayload('Hit', $event->key, $event->value);
+            $payload = new CachePayload('Hit', $event->key, $event->tags, $event->value);
 
             $ray = $this->ray()->sendRequest($payload);
 
@@ -35,7 +35,7 @@ class CacheWatcher extends Watcher
                 return;
             }
 
-            $payload = new CachePayload('Missed', $event->key);
+            $payload = new CachePayload('Missed', $event->key, $event->tags);
 
             $this->ray()->sendRequest($payload);
         });
@@ -48,8 +48,9 @@ class CacheWatcher extends Watcher
             $payload = new CachePayload(
                 'Key written',
                 $event->key,
+                $event->tags,
                 $event->value,
-                $this->formatExpiration($event)
+                $this->formatExpiration($event),
             );
 
             $this->ray()->sendRequest($payload);
@@ -63,6 +64,7 @@ class CacheWatcher extends Watcher
             $payload = new CachePayload(
                 'Key forgotten',
                 $event->key,
+                $event->tags
             );
 
             $this->ray()->sendRequest($payload);


### PR DESCRIPTION
This adds support for [Laravel's cache tags](https://laravel.com/docs/8.x/cache#cache-tags).