### PR TITLE
Try catch `DB::enableQueryLog` to Handle Cases when connection is not setup.

### DIFF
--- a/src/Watchers/DuplicateQueryWatcher.php
+++ b/src/Watchers/DuplicateQueryWatcher.php
@@ -20,11 +20,10 @@ class DuplicateQueryWatcher extends Watcher
 
         $this->enabled = $settings->send_duplicate_queries_to_ray;
 
-        if (! $this->enabled()) {
-            return;
-        }
-
         DB::listen(function (QueryExecuted $query) {
+            if (! $this->enabled()) {
+                return;
+            }
 
             $sql = Str::replaceArray('?', $query->bindings, $query->sql);
 
@@ -46,7 +45,11 @@ class DuplicateQueryWatcher extends Watcher
 
     public function enable(): Watcher
     {
-        DB::enableQueryLog();
+        try {
+            DB::enableQueryLog();
+        } catch (\Throwable $exception){
+            return $this;
+        }
 
         parent::enable();
 

--- a/src/Watchers/DuplicateQueryWatcher.php
+++ b/src/Watchers/DuplicateQueryWatcher.php
@@ -20,10 +20,11 @@ class DuplicateQueryWatcher extends Watcher
 
         $this->enabled = $settings->send_duplicate_queries_to_ray;
 
+        if (! $this->enabled()) {
+            return;
+        }
+
         DB::listen(function (QueryExecuted $query) {
-            if (! $this->enabled()) {
-                return;
-            }
 
             $sql = Str::replaceArray('?', $query->bindings, $query->sql);
 

--- a/src/Watchers/QueryWatcher.php
+++ b/src/Watchers/QueryWatcher.php
@@ -25,10 +25,11 @@ class QueryWatcher extends Watcher
 
         $this->enabled = $settings->send_queries_to_ray;
 
+        if (! $this->enabled()) {
+            return;
+        }
+
         DB::listen(function (QueryExecuted $query) {
-            if (! $this->enabled()) {
-                return;
-            }
 
             if ($this->keepExecutedQueries) {
                 $this->executedQueries[] = $query;

--- a/src/Watchers/QueryWatcher.php
+++ b/src/Watchers/QueryWatcher.php
@@ -25,11 +25,10 @@ class QueryWatcher extends Watcher
 
         $this->enabled = $settings->send_queries_to_ray;
 
-        if (! $this->enabled()) {
-            return;
-        }
-
         DB::listen(function (QueryExecuted $query) {
+            if (! $this->enabled()) {
+                return;
+            }
 
             if ($this->keepExecutedQueries) {
                 $this->executedQueries[] = $query;
@@ -49,7 +48,11 @@ class QueryWatcher extends Watcher
 
     public function enable(): Watcher
     {
-        DB::enableQueryLog();
+        try {
+            DB::enableQueryLog();
+        } catch (\Throwable $exception){
+            return $this;
+        }
 
         parent::enable();
 

--- a/tests/Unit/DuplicateQueryTest.php
+++ b/tests/Unit/DuplicateQueryTest.php
@@ -5,9 +5,20 @@ namespace Spatie\LaravelRay\Tests\Unit;
 use Illuminate\Support\Facades\DB;
 use Spatie\LaravelRay\Tests\TestCase;
 use Spatie\LaravelRay\Tests\TestClasses\User;
+use Spatie\Ray\Settings\Settings;
 
 class DuplicateQueryTest extends TestCase
 {
+    /** @test */
+    public function it_does_not_send_duplicate_queries_to_ray_when_connection_is_not_setup_properly()
+    {
+        config()->set('database.default', 'sqlite_bad');
+
+        ray()->showDuplicateQueries();
+
+        $this->expectNotToPerformAssertions();
+    }
+
     /** @test */
     public function it_can_start_logging_duplicate_queries()
     {

--- a/tests/Unit/QueryTest.php
+++ b/tests/Unit/QueryTest.php
@@ -10,6 +10,16 @@ use Spatie\LaravelRay\Tests\TestClasses\User;
 class QueryTest extends TestCase
 {
     /** @test */
+    public function it_does_not_send_queries_to_ray_when_connection_is_not_setup_properly()
+    {
+        config()->set('database.default', 'sqlite_bad');
+
+        ray()->showQueries();
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    /** @test */
     public function it_can_start_logging_queries()
     {
         ray()->showQueries();


### PR DESCRIPTION
Problem: Vapor injects DB_* -- when deploying to Vapor, DB_* is not set from .env pull thus this fails during composer autoload.