### PR TITLE
Fix #217 error with duplicate queries log 

### DIFF
--- a/src/Watchers/DuplicateQueryWatcher.php
+++ b/src/Watchers/DuplicateQueryWatcher.php
@@ -46,7 +46,7 @@ class DuplicateQueryWatcher extends Watcher
     private function cleanupBindings(array $bindings): array
     {
         return array_map(function ($binding) {
-            if ($binding instanceof \DateTime) {
+            if ($binding instanceof \DateTimeInterface) {
                 return $binding->format('Y-m-d H:i:s');
             }
 

--- a/tests/Unit/DuplicateQueryTest.php
+++ b/tests/Unit/DuplicateQueryTest.php
@@ -84,4 +84,19 @@ class DuplicateQueryTest extends TestCase
 
         $this->assertCount(1, $this->client->sentPayloads());
     }
+
+    /**
+     * @test
+     *
+     * ref. issue https://github.com/spatie/laravel-ray/issues/217
+     */
+    public function it_can_log_duplicated_queries_with_datetime_parameters()
+    {
+        ray()->showDuplicateQueries();
+
+        DB::table('users')->where('created_at', '<', new \DateTime(now()))->get();
+        DB::table('users')->where('created_at', '<', new \DateTime(now()))->get();
+
+        $this->assertCount(1, $this->client->sentRequests());
+    }
 }


### PR DESCRIPTION
Hi @freekmurze,

This pr will fix #217 by adding an handler for unsupported types in query parameters bindings

Also tests have been updated to address this issue

Thanks for your great work! 