### PR TITLE
Fix typo in ray.php docblock

### DIFF
--- a/stub/ray.php
+++ b/stub/ray.php
@@ -2,7 +2,7 @@
 
 return [
     /*
-    * This settings controls whether data should be sent to Ray.
+    * This setting controls whether data should be sent to Ray.
     *
     * By default, `ray()` will only transmit data in non-production environments.
     */


### PR DESCRIPTION
When publishing the `ray.php` config file in a new project, I noticed a small typo in the file documentation.
Since the docblock I updated is about a single setting, it shouldn't use the plural "settings", but singular "setting" instead 🙂 