### PR TITLE
Added DeprecatedNoticeWatcher that piggy backs off of the Application…

### DIFF
--- a/src/RayServiceProvider.php
+++ b/src/RayServiceProvider.php
@@ -16,6 +16,7 @@ use Spatie\LaravelRay\Payloads\ModelPayload;
 use Spatie\LaravelRay\Payloads\QueryPayload;
 use Spatie\LaravelRay\Watchers\ApplicationLogWatcher;
 use Spatie\LaravelRay\Watchers\CacheWatcher;
+use Spatie\LaravelRay\Watchers\DeprecatedNoticeWatcher;
 use Spatie\LaravelRay\Watchers\DumpWatcher;
 use Spatie\LaravelRay\Watchers\DuplicateQueryWatcher;
 use Spatie\LaravelRay\Watchers\EventWatcher;
@@ -76,6 +77,7 @@ class RayServiceProvider extends ServiceProvider
                 'send_http_client_requests_to_ray' => env('SEND_HTTP_CLIENT_REQUESTS_TO_RAY', false),
                 'send_views_to_ray' => env('SEND_VIEWS_TO_RAY', false),
                 'send_exceptions_to_ray' => env('SEND_EXCEPTIONS_TO_RAY', true),
+                'send_deprecated_notices_to_ray' => env('SEND_DEPRECATED_NOTICES_TO_RAY', false),
             ]);
         });
 
@@ -124,6 +126,7 @@ class RayServiceProvider extends ServiceProvider
             CacheWatcher::class,
             RequestWatcher::class,
             HttpClientWatcher::class,
+            DeprecatedNoticeWatcher::class
         ];
 
         collect($watchers)
@@ -149,6 +152,7 @@ class RayServiceProvider extends ServiceProvider
             CacheWatcher::class,
             RequestWatcher::class,
             HttpClientWatcher::class,
+            DeprecatedNoticeWatcher::class
         ];
 
         collect($watchers)

--- a/src/Watchers/ApplicationLogWatcher.php
+++ b/src/Watchers/ApplicationLogWatcher.php
@@ -69,6 +69,10 @@ class ApplicationLogWatcher extends Watcher
             return false;
         }
 
+        if((new DeprecatedNoticeWatcher())->concernsDeprecatedNotice($message)) {
+            return false;
+        }
+
         return true;
     }
 }

--- a/src/Watchers/DeprecatedNoticeWatcher.php
+++ b/src/Watchers/DeprecatedNoticeWatcher.php
@@ -1,0 +1,26 @@
+<?php namespace Spatie\LaravelRay\Watchers;
+
+use Illuminate\Log\Events\MessageLogged;
+use Illuminate\Support\Str;
+use Spatie\Ray\Settings\Settings;
+
+class DeprecatedNoticeWatcher extends Watcher
+{
+
+    public function register() : void
+    {
+        //
+    }
+
+    public function concernsDeprecatedNotice(MessageLogged $messageLogged) : bool
+    {
+        $settings      = app(Settings::class);
+        $this->enabled = $settings->send_deprecated_notices_to_ray;
+
+        if ($this->enabled()) {
+            return false;
+        }
+
+        return Str::contains($messageLogged->message, ['deprecated', 'Deprecated']);
+    }
+}

--- a/tests/RayTest.php
+++ b/tests/RayTest.php
@@ -35,6 +35,24 @@ class RayTest extends TestCase
     }
 
     /** @test */
+    public function it_can_disable_deprecated_notices()
+    {
+        trigger_error('This is deprecated', E_USER_DEPRECATED);
+
+        $this->assertCount(0, $this->client->sentRequests());
+    }
+
+    /** @test */
+    public function it_can_enable_deprecated_notices()
+    {
+        app(Settings::class)->send_deprecated_notices_to_ray = true;
+
+        trigger_error('This is deprecated', E_USER_DEPRECATED);
+
+        $this->assertCount(2, $this->client->sentRequests());
+    }
+
+    /** @test */
     public function it_will_not_send_dumps_to_ray_when_disabled()
     {
         app(Settings::class)->send_dumps_to_ray = false;

--- a/tests/RayTest.php
+++ b/tests/RayTest.php
@@ -37,7 +37,8 @@ class RayTest extends TestCase
     /** @test */
     public function it_can_disable_deprecated_notices()
     {
-        trigger_error('This is deprecated', E_USER_DEPRECATED);
+        Log::warning('Deprecated');
+        Log::warning('deprecated');
 
         $this->assertCount(0, $this->client->sentRequests());
     }
@@ -47,9 +48,10 @@ class RayTest extends TestCase
     {
         app(Settings::class)->send_deprecated_notices_to_ray = true;
 
-        trigger_error('This is deprecated', E_USER_DEPRECATED);
+        Log::warning('Deprecated');
+        Log::warning('deprecated');
 
-        $this->assertCount(2, $this->client->sentRequests());
+        $this->assertCount(4, $this->client->sentRequests());
     }
 
     /** @test */

--- a/tests/RayTest.php
+++ b/tests/RayTest.php
@@ -3,7 +3,7 @@
 namespace Spatie\LaravelRay\Tests;
 
 use Illuminate\Support\Arr;
-use Log;
+use Illuminate\Support\Facades\Log;
 use Spatie\LaravelRay\Tests\Concerns\MatchesOsSafeSnapshots;
 use Spatie\LaravelRay\Tests\TestClasses\TestMailable;
 use Spatie\LaravelRay\Tests\TestClasses\User;


### PR DESCRIPTION
This PR adds a calls the `(new DeprecatedNoticeWatcher())->concernsDeprecatedNotice($message)` method from within the ApplicationLogWatcher. The deprecated log notices are disabled by default.

Adding 
`SEND_DEPRECATED_NOTICES_TO_RAY=true` in the .env file will enable the notices to go out to ray again.