### PR TITLE
Register `DumpRecorder` only once and keep original handler connected

### DIFF
--- a/src/DumpRecorder/DumpRecorder.php
+++ b/src/DumpRecorder/DumpRecorder.php
@@ -29,7 +29,7 @@ class DumpRecorder
             return $multiDumpHandler;
         });
 
-        if (!static::$registeredHandler) {
+        if (! static::$registeredHandler) {
             static::$registeredHandler = true;
 
             $originalHandler = VarDumper::setHandler(function ($dumpedVariable) use ($multiDumpHandler) {

--- a/src/DumpRecorder/DumpRecorder.php
+++ b/src/DumpRecorder/DumpRecorder.php
@@ -29,16 +29,14 @@ class DumpRecorder
             return $multiDumpHandler;
         });
 
-        $handler = function ($dumpedVariable) use ($multiDumpHandler) {
-            if ($this->shouldDump()) {
-                $multiDumpHandler->dump($dumpedVariable);
-            }
-        };
-
-        if (! static::$registeredHandler) {
+        if (!static::$registeredHandler) {
             static::$registeredHandler = true;
 
-            $originalHandler = VarDumper::setHandler($handler);
+            $originalHandler = VarDumper::setHandler(function ($dumpedVariable) use ($multiDumpHandler) {
+                if ($this->shouldDump()) {
+                    $multiDumpHandler->dump($dumpedVariable);
+                }
+            });
 
             if ($originalHandler) {
                 $multiDumpHandler->addHandler($originalHandler);

--- a/src/DumpRecorder/DumpRecorder.php
+++ b/src/DumpRecorder/DumpRecorder.php
@@ -2,12 +2,8 @@
 
 namespace Spatie\LaravelRay\DumpRecorder;
 
-use Closure;
 use Illuminate\Contracts\Container\Container;
 use Spatie\LaravelRay\Ray;
-use Symfony\Component\VarDumper\Cloner\VarCloner;
-use Symfony\Component\VarDumper\Dumper\CliDumper;
-use Symfony\Component\VarDumper\Dumper\HtmlDumper as BaseHtmlDumper;
 use Symfony\Component\VarDumper\VarDumper;
 
 class DumpRecorder
@@ -39,7 +35,7 @@ class DumpRecorder
             }
         };
 
-        if (!static::$registeredHandler) {
+        if (! static::$registeredHandler) {
             static::$registeredHandler = true;
 
             $originalHandler = VarDumper::setHandler($handler);


### PR DESCRIPTION
When using Ray I noticed that Ignition stopped receiving `dump` and `dd` statements. This is because both packages replace the `VarDumper::$handler` with their own implementation and only one `$handler` can be registered at a time.

This PR makes sure the `DumpRecorder` only registers its `MultiDumpHandler` once. It also makes sure that the original `VarDumper::$handler` gets added to the `MultiDumpHandler`.