### PR TITLE
Fix deprecated

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,6 +55,9 @@
         "sort-packages": true
     },
     "extra": {
+        "branch-alias": {
+            "dev-main": "1.29.x-dev"
+        },
         "laravel": {
             "providers": [
                 "Spatie\\LaravelRay\\RayServiceProvider"

--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,14 @@
         }
     ],
     "require": {
-        "ext-json": "*",
         "php": "^7.3|^8.0",
+        "ext-json": "*",
         "illuminate/contracts": "^7.20|^8.19|^9.0",
         "illuminate/database": "^7.20|^8.19|^9.0",
         "illuminate/queue": "^7.20|^8.19|^9.0",
         "illuminate/support": "^7.20|^8.19|^9.0",
+        "laravel/framework": "9.*",
+        "orchestra/testbench": "7.*",
         "spatie/backtrace": "^1.0",
         "spatie/ray": "^1.33",
         "symfony/stopwatch": "4.2|^5.1|^6.0",
@@ -29,7 +31,6 @@
     },
     "require-dev": {
         "guzzlehttp/guzzle": "^7.3",
-        "laravel/framework": "^7.20|^8.19|^9.0",
         "orchestra/testbench-core": "^5.0|^6.0|^7.0",
         "phpstan/phpstan": "^0.12.93",
         "phpunit/phpunit": "^9.3",
@@ -55,6 +56,9 @@
         "sort-packages": true
     },
     "extra": {
+        "branch-alias": {
+            "dev-main": "1.29.x-dev"
+        },
         "laravel": {
             "providers": [
                 "Spatie\\LaravelRay\\RayServiceProvider"

--- a/composer.json
+++ b/composer.json
@@ -16,14 +16,12 @@
         }
     ],
     "require": {
-        "php": "^7.3|^8.0",
         "ext-json": "*",
+        "php": "^7.3|^8.0",
         "illuminate/contracts": "^7.20|^8.19|^9.0",
         "illuminate/database": "^7.20|^8.19|^9.0",
         "illuminate/queue": "^7.20|^8.19|^9.0",
         "illuminate/support": "^7.20|^8.19|^9.0",
-        "laravel/framework": "9.*",
-        "orchestra/testbench": "7.*",
         "spatie/backtrace": "^1.0",
         "spatie/ray": "^1.33",
         "symfony/stopwatch": "4.2|^5.1|^6.0",
@@ -31,6 +29,7 @@
     },
     "require-dev": {
         "guzzlehttp/guzzle": "^7.3",
+        "laravel/framework": "^7.20|^8.19|^9.0",
         "orchestra/testbench-core": "^5.0|^6.0|^7.0",
         "phpstan/phpstan": "^0.12.93",
         "phpunit/phpunit": "^9.3",
@@ -56,9 +55,6 @@
         "sort-packages": true
     },
     "extra": {
-        "branch-alias": {
-            "dev-main": "1.29.x-dev"
-        },
         "laravel": {
             "providers": [
                 "Spatie\\LaravelRay\\RayServiceProvider"

--- a/src/OriginFactory.php
+++ b/src/OriginFactory.php
@@ -145,6 +145,9 @@ class OriginFactory
     protected function findFrameForQueryBuilder(Collection $frames): ?Frame
     {
         $indexOfLastDatabaseCall = $frames
+            ->filter(function (Frame $frame) {
+                return ! is_null($frame->class);
+            })
             ->search(function (Frame $frame) {
                 return Str::startsWith($frame->class, 'Illuminate\Database');
             });

--- a/src/OriginFactory.php
+++ b/src/OriginFactory.php
@@ -132,6 +132,9 @@ class OriginFactory
     protected function findFrameForQuery(Collection $frames): ?Frame
     {
         $indexOfLastDatabaseCall = $frames
+            ->filter(function (Frame $frame) {
+                return ! is_null($frame->class);
+            })
             ->search(function (Frame $frame) {
                 return Str::startsWith($frame->class, 'Illuminate\Database');
             });


### PR DESCRIPTION
I took a look at the backtrace and since it's using the debug_backtrace method from PHP itself and apparently $frame->class can be null there, I figured it's the best way to make this more robust and only look at the frames that have a class to begin with.