### PR TITLE
check if ApplicationLogPayload can be loaded #237

### DIFF
--- a/src/Watchers/ApplicationLogWatcher.php
+++ b/src/Watchers/ApplicationLogWatcher.php
@@ -20,7 +20,12 @@ class ApplicationLogWatcher extends Watcher
             if (! $this->shouldLogMessage($message)) {
                 return;
             }
-
+            
+            // (temporary) workaround for #237 - Class "Spatie\Ray\Payloads\ApplicationLogPayload" not found
+            if (! class_exists('Spatie\Ray\Payloads\ApplicationLogPayload')) {
+                return;
+            }
+            
             $payload = new ApplicationLogPayload($message->message);
 
             /** @var Ray $ray */


### PR DESCRIPTION
workaround for #237 - Class "Spatie\Ray\Payloads\ApplicationLogPayload" not found

This PR is a workaround. It isn't a real solution, but it solves the issue. And many of us are struggling with this for over six weeks.