### PR TITLE
Fix undefined payload when using queue driver other than sync

### DIFF
--- a/src/Payloads/JobEventPayload.php
+++ b/src/Payloads/JobEventPayload.php
@@ -2,7 +2,7 @@
 
 namespace Spatie\LaravelRay\Payloads;
 
-use Illuminate\Queue\Jobs\SyncJob;
+use Illuminate\Queue\Jobs\Job;
 use Spatie\Ray\ArgumentConverter;
 use Spatie\Ray\Payloads\Payload;
 
@@ -21,9 +21,9 @@ class JobEventPayload extends Payload
     {
         $this->event = $event;
 
-        // The sync driver creates an intermediate job, the orignal job is inside the stored payload
+        // Some queue driver uses an intermediate job and the orignal job is stored inside.
         // For other drivers, the job is not altered, it can directly be used
-        if ($event->job instanceof SyncJob) {
+        if ($event->job instanceof Job) {
             $this->job = unserialize($event->job->payload()['data']['command']);
         } else {
             $this->job = $event->job;

--- a/src/Payloads/JobEventPayload.php
+++ b/src/Payloads/JobEventPayload.php
@@ -21,13 +21,11 @@ class JobEventPayload extends Payload
     {
         $this->event = $event;
 
-        // Some queue driver uses an intermediate job and the orignal job is stored inside.
-        // For other drivers, the job is not altered, it can directly be used
-        if ($event->job instanceof Job) {
-            $this->job = unserialize($event->job->payload()['data']['command']);
-        } else {
-            $this->job = $event->job;
-        }
+        // Some queue drivers use an intermediate job with the orignal job stored inside.
+        // For other drivers, the job is not altered, and it can be used directly.
+        $this->job = $event->job instanceof Job
+            ? unserialize($event->job->payload()['data']['command'])
+            : $this->job = $event->job;
 
         if (property_exists($event, 'exception')) {
             $this->exception = $event->exception ?? null;


### PR DESCRIPTION
When `send_jobs_to_ray` is enabled and using the queue driver other than "sync". The package return an error "undefined payload()".

It would seem Laravel has done something, very odd, in my opinion. When using the sync/redis or sqs driver, Laravel creates an intermediate Job `\Illuminate\Queue\Jobs\SyncJob` which means the original job is inside it, but for other drivers (database) it directly returns the orignal job.

This PR has adds a check to retrieve the payload depending on the job received.

This fixes issue [586](https://github.com/spatie/ray/issues/586) of the package spatie/ray

Note: When a job is queued, three event are thrown `JobQueued`, `JobProcessing ` and `JobProcessed ` but only the first one will display the job. Whereas when using the sync driver, the two thrown events `JobProcessing` and `JobProcessed` also display the job. 

When using the database driver:
![Screen Shot 2022-04-05 at 16 34 50](https://user-images.githubusercontent.com/44996807/161778242-a4e42b9e-8aab-4d9f-ab90-0ab49e2021c9.png)

When using the sync driver:
![Screen Shot 2022-04-05 at 16 34 54](https://user-images.githubusercontent.com/44996807/161778249-becd41ac-8b8f-4487-9196-8b4032e06d77.png)
