### PR TITLE
Feat: Slow query configuration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
         "zbateson/mail-mime-parser": "^1.3.1|^2.0"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.9",
         "guzzlehttp/guzzle": "^7.3",
         "laravel/framework": "^7.20|^8.19|^9.0",
         "orchestra/testbench-core": "^5.0|^6.0|^7.0",

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "zbateson/mail-mime-parser": "^1.3.1|^2.0"
     },
     "require-dev": {
+        "friendsofphp/php-cs-fixer": "^3.9",
         "guzzlehttp/guzzle": "^7.3",
         "laravel/framework": "^7.20|^8.19|^9.0",
         "orchestra/testbench-core": "^5.0|^6.0|^7.0",

--- a/src/Watchers/SlowQueryWatcher.php
+++ b/src/Watchers/SlowQueryWatcher.php
@@ -10,7 +10,7 @@ use Spatie\Ray\Settings\Settings;
 
 class SlowQueryWatcher extends QueryWatcher
 {
-    protected int $minimumTimeInMs = 500;
+    protected $minimumTimeInMs = 500;
 
     public function register(): void
     {

--- a/src/Watchers/SlowQueryWatcher.php
+++ b/src/Watchers/SlowQueryWatcher.php
@@ -10,13 +10,14 @@ use Spatie\Ray\Settings\Settings;
 
 class SlowQueryWatcher extends QueryWatcher
 {
-    protected $minimumTimeInMs = 0;
+    protected int $minimumTimeInMs = 500;
 
     public function register(): void
     {
         $settings = app(Settings::class);
 
         $this->enabled = $settings->send_slow_queries_to_ray ?? false;
+        $this->minimumTimeInMs = $settings->slow_query_threshold ?? $this->minimumTimeInMs;
 
         DB::listen(function (QueryExecuted $query) {
             if (! $this->enabled()) {

--- a/src/Watchers/SlowQueryWatcher.php
+++ b/src/Watchers/SlowQueryWatcher.php
@@ -17,7 +17,7 @@ class SlowQueryWatcher extends QueryWatcher
         $settings = app(Settings::class);
 
         $this->enabled = $settings->send_slow_queries_to_ray ?? false;
-        $this->minimumTimeInMs = $settings->slow_query_threshold ?? $this->minimumTimeInMs;
+        $this->minimumTimeInMs = $settings->slow_query_threshold_in_ms ?? $this->minimumTimeInMs;
 
         DB::listen(function (QueryExecuted $query) {
             if (! $this->enabled()) {

--- a/stub/ray.php
+++ b/stub/ray.php
@@ -46,9 +46,9 @@ return [
     'send_slow_queries_to_ray' => env('SEND_SLOW_QUERIES_TO_RAY', false),
 
     /**
-     * The default time, in milliseconds, after which a query will classed as "slow".
+     * Queries that are longer than this number of milliseconds will be regarded as slow.
      */
-    'slow_query_threshold' => env('RAY_SLOW_QUERY_THRESHOLD', 500),
+    'slow_query_threshold_in_ms' => env('RAY_SLOW_QUERY_THRESHOLD_IN_MS', 500),
 
     /*
     * When enabled, all requests made to this app will automatically be sent to Ray.

--- a/stub/ray.php
+++ b/stub/ray.php
@@ -44,7 +44,12 @@ return [
      * When enabled, slow queries will automatically be sent to Ray.
      */
     'send_slow_queries_to_ray' => env('SEND_SLOW_QUERIES_TO_RAY', false),
-    
+
+    /**
+     * The default time, in milliseconds, after which a query will classed as "slow".
+     */
+    'slow_query_threshold' => env('RAY_SLOW_QUERY_THRESHOLD', 500),
+
     /*
     * When enabled, all requests made to this app will automatically be sent to Ray.
     */


### PR DESCRIPTION
The slow query logging uses 500ms when manually activating via `ray()->slowQueries();`. When activated via the `ray.php` config `SEND_SLOW_QUERIES_TO_RAY` value, however, it defaults to 0ms causing all queries to be logged.

This adds a configurable `RAY_SLOW_QUERY_THRESHOLD=500` to the `ray.php` stub.

Additionally, the composer.json offered `format` script, but cs-fixer was not included in the dev dependencies.