### PR TITLE
Added in comment to docblock for linux docker users

### DIFF
--- a/stub/ray.php
+++ b/stub/ray.php
@@ -78,6 +78,7 @@ return [
     /*
     * The host used to communicate with the Ray app.
     * When using Docker on Mac or Windows, you can replace localhost with 'host.docker.internal'
+    * When using Docker on Linux, you can replace localhost with '172.17.0.1'
     * When using Homestead with the VirtualBox provider, you can replace localhost with '10.0.2.2'
     * When using Homestead with the Parallels provider, you can replace localhost with '10.211.55.2'
     */


### PR DESCRIPTION
This is a PR to just satisfy my own annoyance within the `ray.php` file. It lists options for Docker on Mac or Windows but not on Linux.

Now 172.17.0.1 won't work 100% of the time if you're doing custom networking with Docker, but by that point, you'll know to update that IP.

Feel free to dismiss this PR if it's irrelevant, it's more just to satisfy me.