### PR TITLE
Fix broken tests for Laravel 9

### DIFF
--- a/src/DumpRecorder/DumpRecorder.php
+++ b/src/DumpRecorder/DumpRecorder.php
@@ -25,7 +25,7 @@ class DumpRecorder
         $this->app = $app;
 
         if (static::$runningLaravel9 === null) {
-            static::$runningLaravel9 = version_compare(app()->version(), '9.0.0') >= 0;
+            static::$runningLaravel9 = version_compare(app()->version(), '9.0.0', '>=');
         }
     }
 

--- a/src/DumpRecorder/DumpRecorder.php
+++ b/src/DumpRecorder/DumpRecorder.php
@@ -2,9 +2,7 @@
 
 namespace Spatie\LaravelRay\DumpRecorder;
 
-use Composer\InstalledVersions;
 use Illuminate\Contracts\Container\Container;
-use Illuminate\Support\Str;
 use ReflectionMethod;
 use ReflectionProperty;
 use Spatie\LaravelRay\Ray;

--- a/src/DumpRecorder/DumpRecorder.php
+++ b/src/DumpRecorder/DumpRecorder.php
@@ -27,7 +27,7 @@ class DumpRecorder
         $this->app = $app;
 
         if (static::$runningLaravel9 === null) {
-            static::$runningLaravel9 = Str::startsWith(InstalledVersions::getVersion('laravel/framework'), '9.');
+            static::$runningLaravel9 = version_compare(app()->version(), '9.0.0') >= 0;
         }
     }
 

--- a/src/DumpRecorder/DumpRecorder.php
+++ b/src/DumpRecorder/DumpRecorder.php
@@ -31,7 +31,7 @@ class DumpRecorder
             return $multiDumpHandler;
         });
 
-        if (! static::$registeredHandler) {
+        if(! static::$registeredHandler || ! $multiDumpHandler->hasHandlers()) {
             static::$registeredHandler = true;
 
             $this->ensureOriginalHandlerExists();

--- a/src/DumpRecorder/DumpRecorder.php
+++ b/src/DumpRecorder/DumpRecorder.php
@@ -41,7 +41,7 @@ class DumpRecorder
 
 
 
-        if(! static::$registeredHandler || static::$runningLaravel9) {
+        if (! static::$registeredHandler || static::$runningLaravel9) {
             static::$registeredHandler = true;
 
             $multiDumpHandler->resetHandlers();

--- a/src/DumpRecorder/DumpRecorder.php
+++ b/src/DumpRecorder/DumpRecorder.php
@@ -2,7 +2,9 @@
 
 namespace Spatie\LaravelRay\DumpRecorder;
 
+use Composer\InstalledVersions;
 use Illuminate\Contracts\Container\Container;
+use Illuminate\Support\Str;
 use ReflectionMethod;
 use ReflectionProperty;
 use Spatie\LaravelRay\Ray;
@@ -18,9 +20,15 @@ class DumpRecorder
 
     protected static $registeredHandler = false;
 
+    protected static $runningLaravel9 = null;
+
     public function __construct(Container $app)
     {
         $this->app = $app;
+
+        if (static::$runningLaravel9 === null) {
+            static::$runningLaravel9 = Str::startsWith(InstalledVersions::getVersion('laravel/framework'), '9.');
+        }
     }
 
     public function register(): self
@@ -31,8 +39,12 @@ class DumpRecorder
             return $multiDumpHandler;
         });
 
-        if(! static::$registeredHandler || ! $multiDumpHandler->hasHandlers()) {
+
+
+        if(! static::$registeredHandler || static::$runningLaravel9) {
             static::$registeredHandler = true;
+
+            $multiDumpHandler->resetHandlers();
 
             $this->ensureOriginalHandlerExists();
 

--- a/src/DumpRecorder/MultiDumpHandler.php
+++ b/src/DumpRecorder/MultiDumpHandler.php
@@ -20,4 +20,9 @@ class MultiDumpHandler
 
         return $this;
     }
+
+    public function hasHandlers(): bool
+    {
+        return count($this->handlers) > 0;
+    }
 }

--- a/src/DumpRecorder/MultiDumpHandler.php
+++ b/src/DumpRecorder/MultiDumpHandler.php
@@ -21,8 +21,8 @@ class MultiDumpHandler
         return $this;
     }
 
-    public function hasHandlers(): bool
+    public function resetHandlers(): void
     {
-        return count($this->handlers) > 0;
+        $this->handlers = [];
     }
 }


### PR DESCRIPTION
This PR fixes an issue with the dump handler not registering correctly on Laravel 9+.

I'm not sure if this is the best solution, but it is a solution.  Suggestions for improvements/alternatives are welcome.