### PR TITLE
Supports Laravel 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,10 @@
     "require": {
         "ext-json": "*",
         "php": "^7.4|^8.0",
-        "illuminate/contracts": "^7.20|^8.19|^9.0",
-        "illuminate/database": "^7.20|^8.19|^9.0",
-        "illuminate/queue": "^7.20|^8.19|^9.0",
-        "illuminate/support": "^7.20|^8.19|^9.0",
+        "illuminate/contracts": "^7.20|^8.19|^9.0|^10.0",
+        "illuminate/database": "^7.20|^8.19|^9.0|^10.0",
+        "illuminate/queue": "^7.20|^8.19|^9.0|^10.0",
+        "illuminate/support": "^7.20|^8.19|^9.0|^10.0",
         "spatie/backtrace": "^1.0",
         "spatie/ray": "^1.33",
         "symfony/stopwatch": "4.2|^5.1|^6.0",
@@ -30,7 +30,7 @@
     "require-dev": {
         "guzzlehttp/guzzle": "^7.3",
         "laravel/framework": "^7.20|^8.19|^9.0",
-        "orchestra/testbench-core": "^5.0|^6.0|^7.0",
+        "orchestra/testbench-core": "^5.0|^6.0|^7.0|^8.0",
         "pestphp/pest": "^1.22",
         "phpstan/phpstan": "^0.12.93",
         "phpunit/phpunit": "^9.3",


### PR DESCRIPTION
Laravel 10 should be released on 7th February and we should look into adding draft support to a `develop` or `next` branch