### PR TITLE
Make DB connection optional

### DIFF
--- a/src/Watchers/DuplicateQueryWatcher.php
+++ b/src/Watchers/DuplicateQueryWatcher.php
@@ -20,27 +20,29 @@ class DuplicateQueryWatcher extends Watcher
 
         $this->enabled = $settings->send_duplicate_queries_to_ray;
 
-        DB::listen(function (QueryExecuted $query) {
-            if (! $this->enabled()) {
-                return;
-            }
+        if (app()->bound('db')) {
+            DB::listen(function (QueryExecuted $query) {
+                if (!$this->enabled()) {
+                    return;
+                }
 
-            $sql = Str::replaceArray('?', $this->cleanupBindings($query->bindings), $query->sql);
+                $sql = Str::replaceArray('?', $this->cleanupBindings($query->bindings), $query->sql);
 
-            $duplicated = in_array($sql, $this->executedQueries);
+                $duplicated = in_array($sql, $this->executedQueries);
 
-            $this->executedQueries[] = $sql;
+                $this->executedQueries[] = $sql;
 
-            if (! $duplicated) {
-                return;
-            }
+                if (!$duplicated) {
+                    return;
+                }
 
-            $payload = new ExecutedQueryPayload($query);
+                $payload = new ExecutedQueryPayload($query);
 
-            $ray = app(Ray::class)->sendRequest($payload);
+                $ray = app(Ray::class)->sendRequest($payload);
 
-            optional($this->rayProxy)->applyCalledMethods($ray);
-        });
+                optional($this->rayProxy)->applyCalledMethods($ray);
+            });
+        }
     }
 
     private function cleanupBindings(array $bindings): array

--- a/src/Watchers/QueryWatcher.php
+++ b/src/Watchers/QueryWatcher.php
@@ -26,26 +26,28 @@ class QueryWatcher extends Watcher
         $this->enabled = $settings->send_queries_to_ray;
 
         if (app()->bound('db')) {
-            DB::listen(function (QueryExecuted $query) {
-                if (!$this->enabled()) {
-                    return;
-                }
-
-                if ($this->keepExecutedQueries) {
-                    $this->executedQueries[] = $query;
-                }
-
-                if (!$this->sendIndividualQueries) {
-                    return;
-                }
-
-                $payload = new ExecutedQueryPayload($query);
-
-                $ray = app(Ray::class)->sendRequest($payload);
-
-                optional($this->rayProxy)->applyCalledMethods($ray);
-            });
+            return;
         }
+
+        DB::listen(function (QueryExecuted $query) {
+            if (! $this->enabled()) {
+                return;
+            }
+
+            if ($this->keepExecutedQueries) {
+                $this->executedQueries[] = $query;
+            }
+
+            if (! $this->sendIndividualQueries) {
+                return;
+            }
+
+            $payload = new ExecutedQueryPayload($query);
+
+            $ray = app(Ray::class)->sendRequest($payload);
+
+            optional($this->rayProxy)->applyCalledMethods($ray);
+        });
     }
 
     public function enable(): Watcher

--- a/src/Watchers/QueryWatcher.php
+++ b/src/Watchers/QueryWatcher.php
@@ -25,25 +25,27 @@ class QueryWatcher extends Watcher
 
         $this->enabled = $settings->send_queries_to_ray;
 
-        DB::listen(function (QueryExecuted $query) {
-            if (! $this->enabled()) {
-                return;
-            }
+        if (app()->bound('db')) {
+            DB::listen(function (QueryExecuted $query) {
+                if (!$this->enabled()) {
+                    return;
+                }
 
-            if ($this->keepExecutedQueries) {
-                $this->executedQueries[] = $query;
-            }
+                if ($this->keepExecutedQueries) {
+                    $this->executedQueries[] = $query;
+                }
 
-            if (! $this->sendIndividualQueries) {
-                return;
-            }
+                if (!$this->sendIndividualQueries) {
+                    return;
+                }
 
-            $payload = new ExecutedQueryPayload($query);
+                $payload = new ExecutedQueryPayload($query);
 
-            $ray = app(Ray::class)->sendRequest($payload);
+                $ray = app(Ray::class)->sendRequest($payload);
 
-            optional($this->rayProxy)->applyCalledMethods($ray);
-        });
+                optional($this->rayProxy)->applyCalledMethods($ray);
+            });
+        }
     }
 
     public function enable(): Watcher

--- a/src/Watchers/QueryWatcher.php
+++ b/src/Watchers/QueryWatcher.php
@@ -25,7 +25,7 @@ class QueryWatcher extends Watcher
 
         $this->enabled = $settings->send_queries_to_ray;
 
-        if (app()->bound('db')) {
+        if (! app()->bound('db')) {
             return;
         }
 

--- a/src/Watchers/SlowQueryWatcher.php
+++ b/src/Watchers/SlowQueryWatcher.php
@@ -20,22 +20,24 @@ class SlowQueryWatcher extends QueryWatcher
         $this->minimumTimeInMs = $settings->slow_query_threshold_in_ms ?? $this->minimumTimeInMs;
 
         if (app()->bound('db')) {
-            DB::listen(function (QueryExecuted $query) {
-                if (!$this->enabled()) {
-                    return;
-                }
-
-                $ray = app(Ray::class);
-
-                if ($query->time >= $this->minimumTimeInMs) {
-                    $payload = new ExecutedQueryPayload($query);
-
-                    $ray->sendRequest($payload);
-                }
-
-                optional($this->rayProxy)->applyCalledMethods($ray);
-            });
+            return;
         }
+
+        DB::listen(function (QueryExecuted $query) {
+            if (! $this->enabled()) {
+                return;
+            }
+
+            $ray = app(Ray::class);
+
+            if ($query->time >= $this->minimumTimeInMs) {
+                $payload = new ExecutedQueryPayload($query);
+
+                $ray->sendRequest($payload);
+            }
+
+            optional($this->rayProxy)->applyCalledMethods($ray);
+        });
     }
 
     public function setMinimumTimeInMilliseconds(float $milliseconds): self

--- a/src/Watchers/SlowQueryWatcher.php
+++ b/src/Watchers/SlowQueryWatcher.php
@@ -19,7 +19,7 @@ class SlowQueryWatcher extends QueryWatcher
         $this->enabled = $settings->send_slow_queries_to_ray ?? false;
         $this->minimumTimeInMs = $settings->slow_query_threshold_in_ms ?? $this->minimumTimeInMs;
 
-        if (app()->bound('db')) {
+        if (! app()->bound('db')) {
             return;
         }
 

--- a/tests/RayTest.php
+++ b/tests/RayTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Facade;
 use Illuminate\Support\Facades\Log;
 use Spatie\LaravelRay\Ray;
 use Spatie\LaravelRay\RayServiceProvider;
@@ -150,4 +151,15 @@ it('the project name will automatically be set if it something other than larave
     (new RayServiceProvider($this->app))->setProjectName();
 
     expect(Ray::$projectName)->toEqual('my-project');
+});
+
+it('still boots and works although the DB facade has not been bound', function () {
+    unset($this->app['db']);
+    Facade::clearResolvedInstance('db');
+
+    (new RayServiceProvider($this->app))->boot();
+
+    ray('foo');
+
+    expect($this->client->sentRequests())->toHaveCount(1);
 });


### PR DESCRIPTION
Until now Ray did not work when the Laravel project did not use a DB connection (by disabling the DatabaseServiceProvider). That case resulted in a `Target class [db] does not exist.` exception. To solve this, checks are introduced to just ignore the DB watchers.

See: https://github.com/spatie/ray/discussions/771