### PR TITLE
Add context to ApplicationLogPayload

### DIFF
--- a/src/Watchers/ApplicationLogWatcher.php
+++ b/src/Watchers/ApplicationLogWatcher.php
@@ -25,7 +25,7 @@ class ApplicationLogWatcher extends Watcher
                 return;
             }
 
-            $payload = new ApplicationLogPayload($message->message);
+            $payload = new ApplicationLogPayload($message->message, $message->context);
 
             /** @var Ray $ray */
             $ray = app(Ray::class);


### PR DESCRIPTION
The log context is not being passed to the `ApplicationLogPayload` class currently (relates to https://github.com/spatie/laravel-ray/discussions/162) and this PR simply passes that data.

Unfortunately it does **not** mean that the context is shown in Ray, because apparently the formatting of the 

Where is the formatting logic for the `Payload` subclasses? 🤔 is that somewhere in https://github.com/spatie/ray or the Electron app itself?

I propose that we show the message like we currently do, but that we add the context using the same formatter used for the `Spatie\Ray\Payloads\CarbonPayload` class or the `\Spatie\Ray\Payloads\TablePayload`