### PR TITLE
Avoid making DB connection unless necessary

### DIFF
--- a/src/Watchers/DuplicateQueryWatcher.php
+++ b/src/Watchers/DuplicateQueryWatcher.php
@@ -4,6 +4,7 @@ namespace Spatie\LaravelRay\Watchers;
 
 use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Str;
 use Spatie\LaravelRay\Payloads\ExecutedQueryPayload;
 use Spatie\LaravelRay\Ray;
@@ -20,11 +21,7 @@ class DuplicateQueryWatcher extends Watcher
 
         $this->enabled = $settings->send_duplicate_queries_to_ray;
 
-        if (! app()->bound('db')) {
-            return;
-        }
-
-        DB::listen(function (QueryExecuted $query) {
+        Event::listen(QueryExecuted::class, function (QueryExecuted $query) {
             if (! $this->enabled()) {
                 return;
             }
@@ -60,7 +57,11 @@ class DuplicateQueryWatcher extends Watcher
 
     public function enable(): Watcher
     {
-        DB::enableQueryLog();
+        if (app()->bound('db')) {
+            collect(DB::getConnections())->each(function ($connection) {
+                $connection->enableQueryLog();
+            });
+        }
 
         parent::enable();
 

--- a/src/Watchers/SlowQueryWatcher.php
+++ b/src/Watchers/SlowQueryWatcher.php
@@ -3,7 +3,7 @@
 namespace Spatie\LaravelRay\Watchers;
 
 use Illuminate\Database\Events\QueryExecuted;
-use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
 use Spatie\LaravelRay\Payloads\ExecutedQueryPayload;
 use Spatie\LaravelRay\Ray;
 use Spatie\Ray\Settings\Settings;
@@ -19,11 +19,7 @@ class SlowQueryWatcher extends QueryWatcher
         $this->enabled = $settings->send_slow_queries_to_ray ?? false;
         $this->minimumTimeInMs = $settings->slow_query_threshold_in_ms ?? $this->minimumTimeInMs;
 
-        if (! app()->bound('db')) {
-            return;
-        }
-
-        DB::listen(function (QueryExecuted $query) {
+        Event::listen(QueryExecuted::class, function (QueryExecuted $query) {
             if (! $this->enabled()) {
                 return;
             }


### PR DESCRIPTION
- additional improvements to #290

Internally, `DB::listen()` is equivalent to calling `app('db')->connection()->listen()` which initiate a database connection and cause issue such as nunomaduro/larastan#1588