### PR TITLE
feat: support raw sql

### DIFF
--- a/src/Payloads/ExecutedQueryPayload.php
+++ b/src/Payloads/ExecutedQueryPayload.php
@@ -22,7 +22,14 @@ class ExecutedQueryPayload extends Payload
 
     public function getContent(): array
     {
-        $properties = [
+        $grammar = $this->query->connection->getQueryGrammar();
+
+        $properties = method_exists($grammar, 'substituteBindingsIntoRawSql') ? [
+            'sql' => $grammar->substituteBindingsIntoRawSql(
+                $this->query->sql,
+                $this->query->connection->prepareBindings($this->query->bindings)
+            ),
+        ] : [
             'sql' => $this->query->sql,
             'bindings' => $this->query->bindings,
         ];

--- a/src/Payloads/QueryPayload.php
+++ b/src/Payloads/QueryPayload.php
@@ -22,6 +22,12 @@ class QueryPayload extends Payload
 
     public function getContent(): array
     {
+        if (method_exists($this->query, 'toRawSql')) {
+            return [
+                'sql' => $this->query->toRawSql(),
+            ];
+        }
+
         return [
             'sql' => $this->query->toSql(),
             'bindings' => $this->query->getBindings(),


### PR DESCRIPTION
This pull request adds support for the newly added [raw SQL](https://github.com/laravel/framework/pull/47507) feature for Laravel 10.15. The implementation seems a bit verbose, but I couldn't think of another way to not introduce a breaking change.

**Before**

<img width="491" alt="image" src="https://github.com/spatie/laravel-ray/assets/16060559/cca2d0ff-0244-46cc-bacd-229a2f4efb8d">

**After**

<img width="511" alt="image" src="https://github.com/spatie/laravel-ray/assets/16060559/3880b87a-4fcc-4589-b907-7a851789102c">
