### PR TITLE
Add ability to return the results of callable

### DIFF
--- a/src/Ray.php
+++ b/src/Ray.php
@@ -453,7 +453,7 @@ class Ray extends BaseRay
                 $watcher->disable();
             }
 
-            if ($output && (new ReflectionFunction($callable))->hasReturnType()) {
+            if ((new ReflectionFunction($callable))->hasReturnType()) {
                 return $output;
             }
         }

--- a/src/Ray.php
+++ b/src/Ray.php
@@ -15,6 +15,7 @@ use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Testing\Fakes\MailFake;
 use Illuminate\Testing\TestResponse;
 use Illuminate\View\View;
+use ReflectionFunction;
 use Spatie\LaravelRay\Payloads\EnvironmentPayload;
 use Spatie\LaravelRay\Payloads\ExecutedQueryPayload;
 use Spatie\LaravelRay\Payloads\LoggedMailPayload;
@@ -304,7 +305,7 @@ class Ray extends BaseRay
             $watcher->doNotSendIndividualQueries();
         }
 
-        $this->handleWatcherCallable($watcher, $callable);
+        $output = $this->handleWatcherCallable($watcher, $callable);
 
         $executedQueryStatistics = collect($watcher->getExecutedQueries())
 
@@ -324,6 +325,8 @@ class Ray extends BaseRay
             ->sendIndividualQueries();
 
         $this->table($executedQueryStatistics, 'Queries');
+
+        return $output;
     }
 
     public function queries($callable = null)
@@ -431,7 +434,7 @@ class Ray extends BaseRay
         return $this;
     }
 
-    protected function handleWatcherCallable(Watcher $watcher, Closure $callable = null): RayProxy
+    protected function handleWatcherCallable(Watcher $watcher, Closure $callable = null)
     {
         $rayProxy = new RayProxy();
 
@@ -444,10 +447,14 @@ class Ray extends BaseRay
         }
 
         if ($callable) {
-            $callable();
+            $output = $callable();
 
             if (! $wasEnabled) {
                 $watcher->disable();
+            }
+
+            if ($output && (new ReflectionFunction($callable))->hasReturnType()) {
+                return $output;
             }
         }
 

--- a/tests/Unit/QueryTest.php
+++ b/tests/Unit/QueryTest.php
@@ -53,6 +53,16 @@ it('can log all queries in a callable', function () {
     expect($this->client->sentRequests())->toHaveCount(1);
 });
 
+it('can log all queries in a callable and gets results', function () {
+    $results = ray()->showQueries(function (): \Illuminate\Support\Collection {
+        // will be logged
+        return DB::table('users')->where('id', 1)->get();
+    });
+    expect($this->client->sentRequests())->toHaveCount(1);
+    expect($results)->toBeInstanceOf(\Illuminate\Support\Collection::class);
+    expect($results->count())->toEqual(0);
+});
+
 it('show queries can be colorized', function () {
     $this->useRealUuid();
 


### PR DESCRIPTION
This adds the ability to return the results of a callable rather than an instance of `Ray`. If the closure has a return type, assume that the results of the callable should be returned rather than `Ray`.

This started as #313 but did a little research and think this is a pretty elegant solution that gets the best of both worlds!