### PR TITLE
Initial undefined variable before using it

### DIFF
--- a/src/Ray.php
+++ b/src/Ray.php
@@ -475,6 +475,7 @@ class Ray extends BaseRay
 
     public function exception(Throwable $exception, array $meta = [])
     {
+        $payloads = [];
         $payloads[] = new ExceptionPayload($exception, $meta);
 
         if ($exception instanceof QueryException) {


### PR DESCRIPTION
# Changed log

- It should declare the variable before assigning the value.