### PR TITLE
Make implicit nullable param to explicit (PHP 8.4 compatibility)

### DIFF
--- a/src/DumpRecorder/MultiDumpHandler.php
+++ b/src/DumpRecorder/MultiDumpHandler.php
@@ -14,7 +14,7 @@ class MultiDumpHandler
         }
     }
 
-    public function addHandler(callable $callable = null): self
+    public function addHandler(?callable $callable = null): self
     {
         $this->handlers[] = $callable;
 

--- a/src/Payloads/CachePayload.php
+++ b/src/Payloads/CachePayload.php
@@ -22,7 +22,7 @@ class CachePayload extends Payload
     /** @var int|null */
     protected $expirationInSeconds;
 
-    public function __construct(string $type, string $key, $tags, $value = null, int $expirationInSeconds = null)
+    public function __construct(string $type, string $key, $tags, $value = null, ?int $expirationInSeconds = null)
     {
         $this->type = $type;
 

--- a/src/Payloads/MailablePayload.php
+++ b/src/Payloads/MailablePayload.php
@@ -19,7 +19,7 @@ class MailablePayload extends Payload
         return new self(self::renderMailable($mailable), $mailable);
     }
 
-    public function __construct(string $html, Mailable $mailable = null)
+    public function __construct(string $html, ?Mailable $mailable = null)
     {
         $this->html = $html;
 

--- a/src/Ray.php
+++ b/src/Ray.php
@@ -44,7 +44,7 @@ use Throwable;
 
 class Ray extends BaseRay
 {
-    public function __construct(Settings $settings, Client $client = null, string $uuid = null)
+    public function __construct(Settings $settings, ?Client $client = null, ?string $uuid = null)
     {
         // persist the enabled setting across multiple instantiations
         $enabled = static::$enabled;
@@ -487,7 +487,7 @@ class Ray extends BaseRay
         return $this;
     }
 
-    protected function handleWatcherCallable(Watcher $watcher, Closure $callable = null)
+    protected function handleWatcherCallable(Watcher $watcher, ?Closure $callable = null)
     {
         $rayProxy = new RayProxy();
 


### PR DESCRIPTION
Implicitly nullable parameter declarations are deprecated in PHP 8.4 ([ref](https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated)).