### PR TITLE
Update branch alias for version 1.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "1.29.x-dev"
+            "dev-main": "1.x-dev"
         },
         "laravel": {
             "providers": [


### PR DESCRIPTION
Instead of having to update the branch alias for each release, the branch `main` can be an alias for all upcoming `1.x` versions.