### PR TITLE
Add 'measure' directive to RayServiceProvider

### DIFF
--- a/src/RayServiceProvider.php
+++ b/src/RayServiceProvider.php
@@ -234,6 +234,9 @@ class RayServiceProvider extends ServiceProvider
             Blade::directive('ray', function ($expression) {
                 return "<?php ray($expression); ?>";
             });
+            Blade::directive('measure', function () {
+                return '<?php ray()->measure() ?>';
+            });
         });
 
         return $this;


### PR DESCRIPTION
A new Blade directive, 'measure', has been added to the RayServiceProvider.php file. This directive calls ray()->measure() method in the Laravel Blade templates.

```blade
{{-- inside a view --}}

@measure
@php(sleep(10))
@measure
```

```
Total time
10.073 s
Maximum memory usage
32.00 MB
Time since last call
10.073 s
```