### PR TITLE
Install `rector/rector` during first run of `php artisan ray:clean` instead of requiring `rector/rector`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,11 @@
     "require": {
         "ext-json": "*",
         "php": "^7.4|^8.0",
+        "composer-runtime-api": "^2.2",
         "illuminate/contracts": "^7.20|^8.19|^9.0|^10.0|^11.0",
         "illuminate/database": "^7.20|^8.19|^9.0|^10.0|^11.0",
         "illuminate/queue": "^7.20|^8.19|^9.0|^10.0|^11.0",
         "illuminate/support": "^7.20|^8.19|^9.0|^10.0|^11.0",
-        "rector/rector": "^0.19.2|^1.0",
         "spatie/backtrace": "^1.0",
         "spatie/ray": "^1.41.1",
         "symfony/stopwatch": "4.2|^5.1|^6.0|^7.0",
@@ -35,6 +35,7 @@
         "pestphp/pest": "^1.22|^2.0",
         "phpstan/phpstan": "^1.10.57",
         "phpunit/phpunit": "^9.3|^10.1",
+        "rector/rector": "^0.19.2|^1.0",
         "spatie/pest-plugin-snapshots": "^1.1|^2.0",
         "symfony/var-dumper": "^4.2|^5.1|^6.0|^7.0.3"
     },

--- a/src/Commands/CleanRayCommand.php
+++ b/src/Commands/CleanRayCommand.php
@@ -2,8 +2,11 @@
 
 namespace Spatie\LaravelRay\Commands;
 
+use Composer\InstalledVersions;
 use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Facades\Process;
+use Spatie\LaravelRay\Support\Composer;
 
 class CleanRayCommand extends Command
 {
@@ -11,7 +14,7 @@ class CleanRayCommand extends Command
 
     protected $description = 'Remove all Ray calls from your codebase.';
 
-    public function handle()
+    public function handle(Filesystem $files)
     {
         $directories = [
             'app',
@@ -22,6 +25,11 @@ class CleanRayCommand extends Command
             'routes',
             'tests',
         ];
+
+        if (! InstalledVersions::isInstalled('rector/rector')) {
+            (new Composer($files, defined('TESTBENCH_WORKING_PATH') ? TESTBENCH_WORKING_PATH : base_path()))
+                ->requirePackages(['rector/rector'], true, $this->output);
+        }
 
         $this->withProgressBar($directories, function ($directory) {
             $result = Process::run('./vendor/bin/remove-ray.sh ' . $directory);

--- a/src/Support/Composer.php
+++ b/src/Support/Composer.php
@@ -10,6 +10,8 @@ class Composer extends \Illuminate\Support\Composer
     /**
      * Install the given Composer packages into the application.
      *
+     * Override this method for `illuminate/support` 10 and below.
+     *
      * @param  array<int, string>  $packages
      * @param  bool  $dev
      * @param  \Closure|\Symfony\Component\Console\Output\OutputInterface|null  $output

--- a/src/Support/Composer.php
+++ b/src/Support/Composer.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Spatie\LaravelRay\Support;
+
+use Closure;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Composer extends \Illuminate\Support\Composer
+{
+    /**
+     * Install the given Composer packages into the application.
+     *
+     * @param  array<int, string>  $packages
+     * @param  bool  $dev
+     * @param  \Closure|\Symfony\Component\Console\Output\OutputInterface|null  $output
+     * @param  string|null  $composerBinary
+     * @return bool
+     */
+    public function requirePackages(array $packages, bool $dev = false, Closure|OutputInterface|null $output = null, $composerBinary = null)
+    {
+        $command = collect([
+            ...$this->findComposer($composerBinary),
+            'require',
+            ...$packages,
+        ])
+        ->when($dev, function ($command) {
+            $command->push('--dev');
+        })->all();
+
+        return 0 === $this->getProcess($command, ['COMPOSER_MEMORY_LIMIT' => '-1'])
+            ->run(
+                $output instanceof OutputInterface
+                    ? function ($type, $line) use ($output) {
+                        $output->write('    '.$line);
+                    } : $output
+            );
+    }
+}


### PR DESCRIPTION
![CleanShot 2024-11-12 at 08 56 55](https://github.com/user-attachments/assets/f95e6ef8-3b44-4d46-9be1-0221d98ced8c)
