### PR TITLE
Add support for PHPStan 2.0

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.3, 8.2, 8.1, 8.0, 7.4]
+        php: [8.4, 8.3, 8.2, 8.1, 8.0, 7.4]
         laravel: [11.*, 10.*, 9.*, 8.*, 7.*]
         dependency-version: [prefer-stable]
         include:
@@ -35,11 +35,17 @@ jobs:
           - laravel: 10.*
             php: 7.4
           - laravel: 9.*
+            php: 8.4
+          - laravel: 9.*
             php: 8.3
           - laravel: 9.*
             php: 7.4
           - laravel: 8.*
+            php: 8.4
+          - laravel: 8.*
             php: 8.3
+          - laravel: 7.*
+            php: 8.4
           - laravel: 7.*
             php: 8.3
           - laravel: 7.*

--- a/composer.json
+++ b/composer.json
@@ -77,7 +77,7 @@
         }
     },
     "scripts": {
-        "analyse": "vendor/bin/phpstan --memory-limit=512M -vvv",
+        "analyse": "vendor/bin/phpstan",
         "format": "vendor/bin/php-cs-fixer fix --allow-risky=yes",
         "test": "vendor/bin/pest",
         "test-coverage": "vendor/bin/pest --coverage"

--- a/composer.json
+++ b/composer.json
@@ -1,12 +1,11 @@
 {
     "name": "spatie/laravel-ray",
     "description": "Easily debug Laravel apps",
+    "license": "MIT",
     "keywords": [
         "spatie",
         "laravel-ray"
     ],
-    "homepage": "https://github.com/spatie/laravel-ray",
-    "license": "MIT",
     "authors": [
         {
             "name": "Freek Van der Herten",
@@ -15,29 +14,42 @@
             "role": "Developer"
         }
     ],
+    "homepage": "https://github.com/spatie/laravel-ray",
+    "funding": [
+        {
+            "type": "github",
+            "url": "https://github.com/sponsors/spatie"
+        },
+        {
+            "type": "other",
+            "url": "https://spatie.be/open-source/support-us"
+        }
+    ],
     "require": {
+        "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "php": "^7.4|^8.0",
-        "illuminate/contracts": "^7.20|^8.19|^9.0|^10.0|^11.0",
-        "illuminate/database": "^7.20|^8.19|^9.0|^10.0|^11.0",
-        "illuminate/queue": "^7.20|^8.19|^9.0|^10.0|^11.0",
-        "illuminate/support": "^7.20|^8.19|^9.0|^10.0|^11.0",
-        "rector/rector": "^0.19.2|^1.0",
+        "illuminate/contracts": "^7.20 || ^8.19 || ^9.0 || ^10.0 || ^11.0",
+        "illuminate/database": "^7.20 || ^8.19 || ^9.0 || ^10.0 || ^11.0",
+        "illuminate/queue": "^7.20 || ^8.19 || ^9.0 || ^10.0 || ^11.0",
+        "illuminate/support": "^7.20 || ^8.19 || ^9.0 || ^10.0 || ^11.0",
+        "rector/rector": "dev-main",
         "spatie/backtrace": "^1.0",
         "spatie/ray": "^1.41.1",
-        "symfony/stopwatch": "4.2|^5.1|^6.0|^7.0",
-        "zbateson/mail-mime-parser": "^1.3.1|^2.0|^3.0"
+        "symfony/stopwatch": "4.2 || ^5.1 || ^6.0 || ^7.0",
+        "zbateson/mail-mime-parser": "^1.3.1 || ^2.0 || ^3.0"
     },
     "require-dev": {
         "guzzlehttp/guzzle": "^7.3",
-        "laravel/framework": "^7.20|^8.19|^9.0|^10.0|^11.0",
-        "orchestra/testbench-core": "^5.0|^6.0|^7.0|^8.0|^9.0",
-        "pestphp/pest": "^1.22|^2.0",
-        "phpstan/phpstan": "^1.10.57",
-        "phpunit/phpunit": "^9.3|^10.1",
-        "spatie/pest-plugin-snapshots": "^1.1|^2.0",
-        "symfony/var-dumper": "^4.2|^5.1|^6.0|^7.0.3"
+        "laravel/framework": "^7.20 || ^8.19 || ^9.0 || ^10.0 || ^11.0",
+        "orchestra/testbench-core": "^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
+        "pestphp/pest": "^1.22 || ^2.0",
+        "phpstan/phpstan": "^1.10.57 || ^2.0.2",
+        "phpunit/phpunit": "^9.3 || ^10.1",
+        "spatie/pest-plugin-snapshots": "^1.1 || ^2.0",
+        "symfony/var-dumper": "^4.2 || ^5.1 || ^6.0 || ^7.0.3"
     },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "autoload": {
         "psr-4": {
             "Spatie\\LaravelRay\\": "src"
@@ -48,17 +60,11 @@
             "Spatie\\LaravelRay\\Tests\\": "tests"
         }
     },
-    "scripts": {
-        "analyse": "vendor/bin/phpstan",
-        "test": "vendor/bin/pest",
-        "test-coverage": "vendor/bin/pest --coverage",
-        "format": "vendor/bin/php-cs-fixer fix --allow-risky=yes"
-    },
     "config": {
-        "sort-packages": true,
         "allow-plugins": {
             "pestphp/pest-plugin": true
-        }
+        },
+        "sort-packages": true
     },
     "extra": {
         "branch-alias": {
@@ -70,16 +76,10 @@
             ]
         }
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
-    "funding": [
-        {
-            "type": "github",
-            "url": "https://github.com/sponsors/spatie"
-        },
-        {
-            "type": "other",
-            "url": "https://spatie.be/open-source/support-us"
-        }
-    ]
+    "scripts": {
+        "analyse": "vendor/bin/phpstan --memory-limit=512M -vvv",
+        "format": "vendor/bin/php-cs-fixer fix --allow-risky=yes",
+        "test": "vendor/bin/pest",
+        "test-coverage": "vendor/bin/pest --coverage"
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "illuminate/support": "^7.20 || ^8.19 || ^9.0 || ^10.0 || ^11.0",
         "rector/rector": "dev-main",
         "spatie/backtrace": "^1.0",
-        "spatie/ray": "^1.41.1",
+        "spatie/ray": "^1.41.3",
         "symfony/stopwatch": "4.2 || ^5.1 || ^6.0 || ^7.0",
         "zbateson/mail-mime-parser": "^1.3.1 || ^2.0 || ^3.0"
     },

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -16,6 +16,11 @@ parameters:
 			path: src/Watchers/ExceptionWatcher.php
 
 		-
+			message: "#^Call to method createReport\\(\\) on an unknown class Spatie\\\\FlareClient\\\\Flare\\.$#"
+			count: 1
+			path: src/Watchers/ExceptionWatcher.php
+
+		-
 			message: "#^Call to method trim\\(\\) on an unknown class Facade\\\\FlareClient\\\\Truncation\\\\ReportTrimmer\\.$#"
 			count: 1
 			path: src/Watchers/ExceptionWatcher.php
@@ -50,3 +55,37 @@ parameters:
 			count: 1
 			path: src/Watchers/ExceptionWatcher.php
 
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Support\\\\Optional::\\$file.$#"
+			count: 1
+			path: src/OriginFactory.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Support\\\\Optional::\\$lineNumber.$#"
+			count: 1
+			path: src/OriginFactory.php
+
+		-
+			message: "#^Call to an undefined method Illuminate\\\\Support\\\\Optional::applyCalledMethods\\(\\).$#"
+			count: 10
+			path: src/
+
+		-
+			message: "#^Call to an undefined method Illuminate\\\\Support\\\\Optional::getActionName\\(\\).$#"
+			count: 1
+			path: src/Watchers/RequestWatcher.php
+
+		-
+			message: "#^Call to an undefined method Illuminate\\\\Support\\\\Optional::gatherMiddleware\\(\\).$#"
+			count: 1
+			path: src/Watchers/RequestWatcher.php
+
+		-
+			message: "#^Access to protected property Illuminate\\\\Support\\\\Collection::\\$items.$#"
+			count: 2
+			path: src/RayServiceProvider.php
+
+		-
+			message: "#^Access to protected property Illuminate\\\\Support\\\\Stringable::\\$value.$#"
+			count: 2
+			path: src/RayServiceProvider.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -11,9 +11,3 @@ parameters:
         - '#^Call to method \w+\(\) on an unknown class Spatie\\WordPressRay\\Ray\.$#'
         - '#^Call to method \w+\(\) on an unknown class Spatie\\RayBundle\\Ray\.$#'
         - '#^Access to an undefined property Spatie\\Ray\\Settings\\Settings\:\:\$\w+\.$#'
-        -
-            message: '#^Access to an undefined property Spatie\\LaravelRay\\RayServiceProvider\:\:\$items\.$#'
-            path: src/RayServiceProvider.php
-        -
-            message: '#^Access to an undefined property Spatie\\LaravelRay\\RayServiceProvider\:\:\$value\.$#'
-            path: src/RayServiceProvider.php


### PR DESCRIPTION
This PR resolves https://github.com/spatie/laravel-ray/issues/366

Currently anyone wishing to use PHPStan 2.0 / LaraStan 3.0 are unable to utilise the awesome sauce of Spatie Ray. This is related to package `rector/rector`, which currently no release tagged for PHPStan 2.0 yet. But it's in the testing phase see the open issue for more details https://github.com/rectorphp/rector/issues/8815#issuecomment-2493467044

Please note once the release has been tagged and released for `rector/rector` I will update this PR with the tags correctly for the `rector/rector` in the `composer.json` file.

I've also taken the feedback raised in https://github.com/spatie/laravel-ray/pull/364 and made changes to the `phpstan-baseline.neon` file.

Related PR: https://github.com/spatie/ray/pull/946