### PR TITLE
Update Dependencies

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,14 +15,19 @@ jobs:
         include:
           - laravel: 11.*
             testbench: 9.*
+            rector: 2.*
           - laravel: 10.*
             testbench: 8.*
+            rector: 1.*
           - laravel: 9.*
             testbench: 7.*
+            rector: 1.*
           - laravel: 8.*
             testbench: 6.*
+            rector: 1.*
           - laravel: 7.*
             testbench: 5.*
+            rector: 0.19.*
         exclude:
           - laravel: 11.*
             php: 8.1
@@ -73,7 +78,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer update --${{ matrix.dependency-version }} --with=laravel/framework:${{ matrix.laravel }} --with=orchestra/testbench-core:${{ matrix.testbench }} --prefer-dist --no-interaction
+          composer update --${{ matrix.dependency-version }} --with=laravel/framework:${{ matrix.laravel }} --with=orchestra/testbench-core:${{ matrix.testbench }} --with=rector/rector:${{ matrix.rector }} --prefer-dist --no-interaction
 
       - name: Execute tests
         run: vendor/bin/pest

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "illuminate/database": "^7.20 || ^8.19 || ^9.0 || ^10.0 || ^11.0",
         "illuminate/queue": "^7.20 || ^8.19 || ^9.0 || ^10.0 || ^11.0",
         "illuminate/support": "^7.20 || ^8.19 || ^9.0 || ^10.0 || ^11.0",
-        "spatie/backtrace": "^1.0",
+        "spatie/backtrace": "^1.7.1",
         "spatie/ray": "^1.41.3",
         "symfony/stopwatch": "4.2 || ^5.1 || ^6.0 || ^7.0",
         "zbateson/mail-mime-parser": "^1.3.1 || ^2.0 || ^3.0"
@@ -44,7 +44,7 @@
         "orchestra/testbench-core": "^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
         "pestphp/pest": "^1.22 || ^2.0",
         "phpstan/phpstan": "^1.10.57 || ^2.0.2",
-        "phpunit/phpunit": "^9.3 || ^10.1",
+        "phpunit/phpunit": "^9.3 || ^10.1 || ^11.0.10",
         "rector/rector": "^0.19.2 || ^1.0.1 || ^2.0.0",
         "spatie/pest-plugin-snapshots": "^1.1 || ^2.0",
         "symfony/var-dumper": "^4.2 || ^5.1 || ^6.0 || ^7.0.3"

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "pestphp/pest": "^1.22 || ^2.0",
         "phpstan/phpstan": "^1.10.57 || ^2.0.2",
         "phpunit/phpunit": "^9.3 || ^10.1",
-        "rector/rector": "dev-main",
+        "rector/rector": "^0.19.2 || ^1.0.1 || ^2.0.0",
         "spatie/pest-plugin-snapshots": "^1.1 || ^2.0",
         "symfony/var-dumper": "^4.2 || ^5.1 || ^6.0 || ^7.0.3"
     },

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -11,3 +11,6 @@ parameters:
         - '#^Call to method \w+\(\) on an unknown class Spatie\\WordPressRay\\Ray\.$#'
         - '#^Call to method \w+\(\) on an unknown class Spatie\\RayBundle\\Ray\.$#'
         - '#^Access to an undefined property Spatie\\Ray\\Settings\\Settings\:\:\$\w+\.$#'
+        -
+            message: '#Unsafe usage of new static\(\).#'
+            reportUnmatched: false


### PR DESCRIPTION
This pull request includes updates to dependencies and configuration files to support new versions and improve testing workflows. The most important changes include adding support for new `rector` versions in the testing matrix, updating dependencies in `composer.json`, and adding a new PHPStan rule.

### Updates to testing workflows:

* [`.github/workflows/run-tests.yml`](diffhunk://#diff-7314d0ebbd2e9537ae4889316745b4fd2fa43cb86275c9caae18a86ba228b642R18-R30): Added new `rector` versions to the testing matrix for various `laravel` and `testbench` versions.
* [`.github/workflows/run-tests.yml`](diffhunk://#diff-7314d0ebbd2e9537ae4889316745b4fd2fa43cb86275c9caae18a86ba228b642L76-R81): Modified the `composer update` command to include `rector` dependencies.

### Dependency updates:

* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L36-R36): Updated `spatie/backtrace` to version `^1.7.1`.
* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L47-R48): Updated `phpunit/phpunit` to include version `^11.0.10` and `rector/rector` to include versions `^0.19.2`, `^1.0.1`, and `^2.0.0`.

### PHPStan configuration:

* [`phpstan.neon.dist`](diffhunk://#diff-6f19df6a6307a48db0940e6897591fb08776d2db8a6134737aa708defdb5c92dR14-R16): Added a new rule to ignore warnings about unsafe usage of `new static()`.

Related to PR https://github.com/spatie/ray/pull/955