### PR TITLE
Fix unnecessary consecutive spaces in comment

### DIFF
--- a/stub/ray.php
+++ b/stub/ray.php
@@ -9,7 +9,7 @@ return [
     'enable' => env('RAY_ENABLED', true),
 
     /*
-    * When enabled, all cache events  will automatically be sent to Ray.
+    * When enabled, all cache events will automatically be sent to Ray.
     */
     'send_cache_to_ray' => env('SEND_CACHE_TO_RAY', false),
 


### PR DESCRIPTION
Removes extra space in cache events comment to improve readability and prevent IDE warnings when using the stub file.