### PR TITLE
Remove duplicate MailWatcher from RayServiceProvider

### DIFF
--- a/src/RayServiceProvider.php
+++ b/src/RayServiceProvider.php
@@ -191,7 +191,6 @@ class RayServiceProvider extends ServiceProvider
             RequestWatcher::class,
             HttpClientWatcher::class,
             DeprecatedNoticeWatcher::class,
-            MailWatcher::class,
         ];
 
         collect($watchers)


### PR DESCRIPTION
The `MailWatcher::class` is defined twice in the `$watchers` array on line 177 and 194. This causes the function `registerMessageSendingEventListener` to be executed twice, which creates a duplicate listener on the `MessageSending` event. I discovered this while sifting through duplicate listeners in the output of `php artisan event:list` in my own application.