### PR TITLE
Use connection name from `QueryException` when creating `QueryExecuted` event

### DIFF
--- a/src/Ray.php
+++ b/src/Ray.php
@@ -610,7 +610,9 @@ class Ray extends BaseRay
         $payloads[] = new ExceptionPayload($exception, $meta);
 
         if ($exception instanceof QueryException) {
-            $executedQuery = new QueryExecuted($exception->getSql(), $exception->getBindings(), null, DB::connection(config('database.default')));
+            $connection = $exception->connectionName ?? config('database.default');
+
+            $executedQuery = new QueryExecuted($exception->getSql(), $exception->getBindings(), null, DB::connection($connection));
 
             $payloads[] = new ExecutedQueryPayload($executedQuery);
         }


### PR DESCRIPTION
I'm working on a multi-tenant / multi-DB application which has no default connection as it is resolved at request time. Various things like Commands use `DB::usingConnection()` to temporarily set a default connection, but exceptions cascade back out of this callback and by the time Ray processes it, there is no default. This causes an exception as `null` gets passed to `DB::connection()`, which masks the original exception and is very annoying.

`QueryException` holds the connection name so I've simply updated it to use that. It falls back to the default as the property was added in Laravel 10.x and Ray looks to support back to 7.x.

There are currently no tests covering `QueryException`s so I haven't added any for this minor change. I can look into covering that path if needed.