### PR TITLE
Defer Ray resolution to boot phase

### DIFF
--- a/src/RayServiceProvider.php
+++ b/src/RayServiceProvider.php
@@ -48,18 +48,18 @@ class RayServiceProvider extends ServiceProvider
         $this
             ->registerCommands()
             ->registerSettings()
-            ->setProjectName()
             ->registerBindings()
             ->registerWatchers()
             ->registerMacros()
-            ->registerBindings()
             ->registerBladeDirectives()
             ->registerPayloadFinder();
     }
 
     public function boot()
     {
-        $this->bootWatchers();
+        $this
+            ->setProjectName()
+            ->bootWatchers();
     }
 
     protected function registerCommands(): self
@@ -115,18 +115,16 @@ class RayServiceProvider extends ServiceProvider
 
     protected function registerBindings(): self
     {
-        $settings = app(Settings::class);
+        $this->app->bind(Client::class, function ($app) {
+            $settings = $app->make(Settings::class);
 
-        $this->app->bind(Client::class, function () use ($settings) {
             return new Client($settings->port, $settings->host);
         });
 
-        $this->app->bind(Ray::class, function () {
-            $client = app(Client::class);
+        $this->app->bind(Ray::class, function ($app) {
+            $settings = $app->make(Settings::class);
 
-            $settings = app(Settings::class);
-
-            $ray = new Ray($settings, $client);
+            $ray = new Ray($settings, $app->make(Client::class));
 
             if (! $settings->enable) {
                 $ray->disable();

--- a/tests/RayTest.php
+++ b/tests/RayTest.php
@@ -163,3 +163,16 @@ it('still boots and works although the DB facade has not been bound', function (
 
     expect($this->client->sentRequests())->toHaveCount(1);
 });
+
+it('does not resolve the ray helper during register when the project name is customised', function () {
+    Ray::$projectName = '';
+    config()->set('app.name', 'my-project');
+
+    (new RayServiceProvider($this->app))->register();
+
+    expect(Ray::$projectName)->toEqual('');
+
+    (new RayServiceProvider($this->app))->boot();
+
+    expect(Ray::$projectName)->toEqual('my-project');
+});


### PR DESCRIPTION
## Summary

Fixes #414 (and the earlier #399) where users on PHP 8.5 see the RayServiceProvider fail with two paired errors during app boot:

- `ReflectionException: Class "request" does not exist`
- `Unresolvable dependency resolving [Parameter #0 [ <required> array $settings ]] in class Spatie\Ray\Settings\Settings`

The root cause is that `register()` triggers eager container resolution before all providers have had a chance to register their bindings.

- `setProjectName()` called `ray()` during register whenever `APP_NAME !== 'Laravel'`. That autowires `Spatie\LaravelRay\Ray` before its own closure has been bound (it is bound two steps later in `registerBindings()`), pulling `Settings` through reflection from a partially configured container.
- `registerBindings()` called `app(Settings::class)` at register time and captured the instance in a `use ($settings)` closure, so any transient resolution failure surfaced as the unresolvable `array $settings` primitive.
- `registerBindings()` was also listed twice in the register chain.

## Changes

- Move `setProjectName()` from `register()` to `boot()` so the helper only runs once every provider has registered.
- Resolve `Settings` lazily inside the `Client` and `Ray` binding closures instead of eagerly at register time.
- Drop the duplicate `registerBindings()` call.
- Add a regression test that customises `app.name` and asserts `Ray::\$projectName` is only set during `boot()`, not `register()`.