### PR TITLE
Fix strtolower null deprecation in RequestWatcher (PHP 8.1+)

### DIFF
--- a/src/Watchers/RequestWatcher.php
+++ b/src/Watchers/RequestWatcher.php
@@ -92,7 +92,7 @@ class RequestWatcher extends Watcher
                 return json_decode($content, true);
             }
 
-            if (Str::startsWith(strtolower($response->headers->get('Content-Type')), 'text/plain')) {
+            if (Str::startsWith(strtolower($response->headers->get('Content-Type') ?? ''), 'text/plain')) {
                 return $content;
             }
         }


### PR DESCRIPTION
# Suggested contribution — spatie/laravel-ray

Repository: https://github.com/spatie/laravel-ray

---

## Issue title

`Fix strtolower null deprecation in RequestWatcher (PHP 8.1+)`

---

## Description

In PHP 8.1+, passing `null` to `strtolower()` generates a deprecation warning:

```
strtolower(): Passing null to parameter #1 ($string) of type string is deprecated
```

This happens in `RequestWatcher::response()` when the `Content-Type` header is absent from the response. `$response->headers->get('Content-Type')` returns `null` in that case, and the result is passed directly to `strtolower()`.

**File:** `src/Watchers/RequestWatcher.php`, line 95

---

## Fix

```diff
- if (Str::startsWith(strtolower($response->headers->get('Content-Type')), 'text/plain')) {
+ if (Str::startsWith(strtolower($response->headers->get('Content-Type') ?? ''), 'text/plain')) {
```

When `Content-Type` is absent, the value falls back to an empty string `''`. `Str::startsWith('', 'text/plain')` returns `false`, preserving the existing behaviour with no functional change.

---

## Reproduction

Any request that does not include a `Content-Type` response header (e.g. redirects, some JSON APIs, binary responses) will trigger the warning when the `RequestWatcher` is active.
